### PR TITLE
To add support for P construct (for | and + operations), and K construct

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -184,7 +184,7 @@ To check permission, simply use Django builtin API::
 Decorators
 ~~~~~~~~~~
 
-Trusts provides a decorator that check permission on object level. (the builtin one only verify permission at model level)::
+Trusts provides a decorator that check permission on object level. (in contrast to builtin one only verify permission at model level)::
 
    from trusts.decorators import permission_required
    from app.models import Xyz
@@ -194,14 +194,33 @@ Trusts provides a decorator that check permission on object level. (the builtin 
      # ...
      pass
 
-   @permission_required('app.change_xyz', fieldlookups_kwargs={'pk': 'xyz_id'})
-   @permission_required('app.read_project', fieldlookups_kwargs={'pk': 'project_id'})
-   def move_xyz_to_project_view(request, xyz_id, project_id):
+The argument `fieldlookups_kwargs` specifies the mapping between permissible object's field and view's arguments list.
+
+The mapping is used to load the permissible object for permission check.
+
+
+K(), G(), O() Lookups
++++++++++++++++++++++
+
+Alternatively, `fieldlookups_kwargs` can be expressed with K() lookup.
+
+   from trusts.decorators import permission_required, K, G, O
+   from app.models import Xyz
+
+   @permission_required('app.change_xyz', pk=K('xyz_id'))
+   def edit_xyz_view(request, xyz_id):
      # ...
      pass
 
+Similar to K() lookup, G() and O() can also be used.
+
+G() lookup maps permissible object's field and request's GET dict.
+
+G() lookup maps permissible object's field and request's POST dict.
+
+
 Permission Conditions
-~~~~~~~~~~~~~~~~~~~~~
++++++++++++++++++++++
 
 In additional ``Group`` and ``Permission`` based check, object level permission condition can be used.
 
@@ -217,10 +236,26 @@ To check ``own`` permission, a colon and the condition name should be added afte
 
 Condition can also be used with decorator as follow::
 
-   @permission_required('app.change_receipt:own', fieldlookups_kwargs={'pk': 'pk'})
+   @permission_required('app.change_receipt:own', pk=K('pk'))
    def edit_receipt_view(request, pk):
      # ...
      pass
+
+
+P() Expressions
++++++++++++++++
+
+Trusts' decorator supports P() expression, permitting the construction of compound permission using | (OR) and & (AND) operators;
+In particular, it is not otherwise possible to use OR in permission.
+
+   from trusts.decorators import permission_required, P, K, G, O
+   from app.models import Xyz
+
+   @permission_required(P('app.change_project:own', pk=K('project_id')) | P('app.move_receipt', pk=O('receipt_id')))
+   def move_xyz_to_project_view(request, project_id):
+     # ...
+     pass
+
 
 Customization
 ~~~~~~~~~~~~~

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-trusts',
-    version='0.10.2',
+    version='0.10.3',
     description='Django authorization add-on for multiple organizations and object-level permission settings',
     author='Thomas Yip',
     author_email='thomasleaf@gmail.com',

--- a/trusts/tests.py
+++ b/trusts/tests.py
@@ -864,77 +864,126 @@ class PTest(ContentModelMixin, TestCase):
         request.META['SERVER_NAME'] = 'beedesk.com'
         request.META['SERVER_PORT'] = 80
         self.request = request
-    '''
-    def test_P(self):
-        p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p.check(self.request, pk=self.content1.pk))
-
-        p = P(self.get_perm_code(self.perm_delete), fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p.check(self.request, pk=self.content2.pk))'''
 
     def test_P(self):
         p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p.check(self.request, pk=self.content1.pk))
-        self.assertTrue(p.check(self.request, pk=self.content2.pk))
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertTrue(mock.called)
+
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content2.pk)
+        self.assertTrue(mock.called)
 
         p = P(self.get_perm_code(self.perm_delete), fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p.check(self.request, pk=self.content1.pk))
-        self.assertFalse(p.check(self.request, pk=self.content2.pk))
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertTrue(mock.called)
+
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content2.pk)
+        self.assertFalse(mock.called)
 
     def test_P_and(self):
         p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'}) & \
             P(self.get_perm_code(self.perm_delete), fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p.check(self.request, pk=self.content1.pk))
-        self.assertFalse(p.check(self.request, pk=self.content2.pk))
+
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertTrue(mock.called)
+
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content2.pk)
+        self.assertFalse(mock.called)
 
         p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'}) & \
             P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'})
-        self.assertFalse(p.check(self.request, pk=self.content1.pk))
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertFalse(mock.called)
 
     def test_P_or(self):
         p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'}) | \
             P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p.check(self.request, pk=self.content1.pk))
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertTrue(mock.called)
 
         p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'}) | \
             P(self.get_perm_code(self.perm_delete), fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p.check(self.request, pk=self.content1.pk))
-        self.assertTrue(p.check(self.request, pk=self.content2.pk))
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertTrue(mock.called)
+
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content2.pk)
+        self.assertTrue(mock.called)
 
         p = P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'}) | \
             P('auth.falsefalseperm_group', fieldlookups_kwargs={'pk': 'pk'})
-        self.assertFalse(p.check(self.request, pk=self.content1.pk))
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertFalse(mock.called)
 
     def test_P_complex(self):
         p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'}) | \
             (P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'}) &
              P('admin.change_all'))
-        self.assertTrue(p.check(self.request, pk=self.content1.pk))
-        self.assertTrue(p.check(self.request, pk=self.content2.pk))
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertTrue(mock.called)
+
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content2.pk)
+        self.assertTrue(mock.called)
 
         p = (P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'}) |
              P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'})) & \
             P('admin.change_all')
-        self.assertFalse(p.check(self.request, pk=self.content1.pk))
-        self.assertFalse(p.check(self.request, pk=self.content2.pk))
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertFalse(mock.called)
+
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content2.pk)
+        self.assertFalse(mock.called)
 
         p1 = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'})
         p2 = P(self.get_perm_code(self.perm_delete), fieldlookups_kwargs={'pk': 'pk'})
         p3 = P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'})
         p4 = P('auth.falsefalseperm_group', fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p1.check(self.request, pk=self.content1.pk))
-        self.assertTrue(p2.check(self.request, pk=self.content1.pk))
-        self.assertFalse(p3.check(self.request, pk=self.content1.pk))
-        self.assertFalse(p4.check(self.request, pk=self.content1.pk))
+        mock = Mock(return_value='Response')
+        permission_required(p1, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertTrue(mock.called)
+
+        mock = Mock(return_value='Response')
+        permission_required(p2, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertTrue(mock.called)
+
+        mock = Mock(return_value='Response')
+        permission_required(p3, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertFalse(mock.called)
+
+        mock = Mock(return_value='Response')
+        permission_required(p4, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertFalse(mock.called)
 
         p = (p1 | p3) & (p2 | p4)
-        self.assertTrue(p.check(self.request, pk=self.content1.pk))
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertTrue(mock.called)
 
         p = (p1 & p3) | (p2 & p4)
-        self.assertFalse(p.check(self.request, pk=self.content1.pk))
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertFalse(mock.called)
 
         p = (p1 & p2) | (p3 & p4)
-        self.assertTrue(p.check(self.request, pk=self.content1.pk))
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertTrue(mock.called)
 
         p = (p1 & p3) | (p2 & p4) | p1
-        self.assertTrue(p.check(self.request, pk=self.content1.pk))
+        mock = Mock(return_value='Response')
+        permission_required(p, raise_exception=False)(mock)(self.request, pk=self.content1.pk)
+        self.assertTrue(mock.called)

--- a/trusts/tests.py
+++ b/trusts/tests.py
@@ -29,7 +29,6 @@ from trusts.models import Trust, TrustManager, Content, Junction, \
                           Role, RolePermission, TrustUserPermission
 from trusts.backends import TrustModelBackend
 from trusts.decorators import permission_required, P
-from trustup.models import GroupJunction
 
 
 def create_test_users(test):
@@ -269,119 +268,6 @@ class DecoratorsTest(TestCase):
         self.assertIsNotNone(filter)
         self.assertEqual(filter.count(), 1)
         self.assertEqual(filter.first().pk, self.group.pk)
-
-
-class PTest(TestCase):
-    def setUp(self):
-        super(PTest, self).setUp()
-
-        call_command('create_trust_root')
-        get_or_create_root_user(self)
-        create_test_users(self)
-        self.group1 = Group.objects.create(name='Test group 1')
-        self.group2 = Group.objects.create(name='Test group 2')
-
-        request = HttpRequest()
-        setattr(request, 'user', self.user)
-        request.META['SERVER_NAME'] = 'beedesk.com'
-        request.META['SERVER_PORT'] = 80
-        self.request = request
-
-        # Change perm for g1 and g2
-        for g in [self.group2, self.group1]:
-            trust = Trust(settlor=self.user, trust=Trust.objects.get_root(), title='Trust for group %s' % g.pk)
-            trust.save()
-            perm = Permission.objects.get(codename='change_group')
-            group = Group.objects.get(pk=g.pk)
-
-            self.user.groups.add(group)
-            perm.group_set.add(group)
-
-            junction = GroupJunction(trust=trust, content=g)
-            junction.save()
-
-            tup = TrustUserPermission(trust=trust, entity=self.user, permission=perm)
-            tup.save()
-
-        # Delete perm only for g1
-        perm = Permission.objects.get(codename='delete_group')
-        group = Group.objects.get(pk=self.group1.pk)
-
-        self.user.groups.add(group)
-        perm.group_set.add(group)
-
-        tup = TrustUserPermission(trust=trust, entity=self.user, permission=perm)
-        tup.save()
-
-        reload_test_users(self)
-        setattr(request, 'user', self.user)
-
-    def test_P(self):
-        p = P('auth.change_group', fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p.check(self.request, pk=self.group1.pk))
-        self.assertTrue(p.check(self.request, pk=self.group2.pk))
-
-        p = P('auth.delete_group', fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p.check(self.request, pk=self.group1.pk))
-        self.assertFalse(p.check(self.request, pk=self.group2.pk))
-
-    def test_P_and(self):
-        p = P('auth.change_group', fieldlookups_kwargs={'pk': 'pk'}) & \
-            P('auth.delete_group', fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p.check(self.request, pk=self.group1.pk))
-        self.assertFalse(p.check(self.request, pk=self.group2.pk))
-
-        p = P('auth.change_group', fieldlookups_kwargs={'pk': 'pk'}) & \
-            P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'})
-        self.assertFalse(p.check(self.request, pk=self.group1.pk))
-
-    def test_P_or(self):
-        p = P('auth.change_group', fieldlookups_kwargs={'pk': 'pk'}) | \
-            P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p.check(self.request, pk=self.group1.pk))
-
-        p = P('auth.change_group', fieldlookups_kwargs={'pk': 'pk'}) | \
-            P('auth.delete_group', fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p.check(self.request, pk=self.group1.pk))
-        self.assertTrue(p.check(self.request, pk=self.group2.pk))
-
-        p = P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'}) | \
-            P('auth.falsefalseperm_group', fieldlookups_kwargs={'pk': 'pk'})
-        self.assertFalse(p.check(self.request, pk=self.group1.pk))
-
-    def test_P_complex(self):
-        p = P('auth.change_group', fieldlookups_kwargs={'pk': 'pk'}) | \
-            (P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'}) &
-             P('admin.change_all'))
-        self.assertTrue(p.check(self.request, pk=self.group1.pk))
-        self.assertTrue(p.check(self.request, pk=self.group2.pk))
-
-        p = (P('auth.change_group', fieldlookups_kwargs={'pk': 'pk'}) |
-             P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'})) & \
-            P('admin.change_all')
-        self.assertFalse(p.check(self.request, pk=self.group1.pk))
-        self.assertFalse(p.check(self.request, pk=self.group2.pk))
-
-        p1 = P('auth.change_group', fieldlookups_kwargs={'pk': 'pk'})
-        p2 = P('auth.delete_group', fieldlookups_kwargs={'pk': 'pk'})
-        p3 = P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'})
-        p4 = P('auth.falsefalseperm_group', fieldlookups_kwargs={'pk': 'pk'})
-        self.assertTrue(p1.check(self.request, pk=self.group1.pk))
-        self.assertTrue(p2.check(self.request, pk=self.group1.pk))
-        self.assertFalse(p3.check(self.request, pk=self.group1.pk))
-        self.assertFalse(p4.check(self.request, pk=self.group1.pk))
-
-        p = (p1 | p3) & (p2 | p4)
-        self.assertTrue(p.check(self.request, pk=self.group1.pk))
-
-        p = (p1 & p3) | (p2 & p4)
-        self.assertFalse(p.check(self.request, pk=self.group1.pk))
-
-        p = (p1 & p2) | (p3 & p4)
-        self.assertTrue(p.check(self.request, pk=self.group1.pk))
-
-        p = (p1 & p3) | (p2 & p4) | p1
-        self.assertTrue(p.check(self.request, pk=self.group1.pk))
 
 
 class RuntimeModel(object):
@@ -947,3 +833,108 @@ class RoleContentTestCase(RoleTestMixin, ContentModelMixin, TransactionTestCase)
 
 class RoleJunctionTestCase(RoleTestMixin, JunctionModelMixin, TransactionTestCase):
     pass
+
+
+class PTest(ContentModelMixin, TestCase):
+    def setUp(self):
+        super(PTest, self).setUp()
+
+        self.trust1 = Trust(settlor=self.user, trust=Trust.objects.get_root())
+        self.trust1.save()
+        
+        self.trust2 = Trust(settlor=self.user1, trust=Trust.objects.get_root())
+        self.trust2.save()
+        
+        self.content1 = self.create_content(self.trust1)
+        self.content2 = self.create_content(self.trust2)
+
+        tup = TrustUserPermission(trust=self.trust1, entity=self.user, permission=self.perm_change)
+        tup.save()
+
+        tup = TrustUserPermission(trust=self.trust1, entity=self.user, permission=self.perm_delete)
+        tup.save()
+        
+        tup = TrustUserPermission(trust=self.trust2, entity=self.user, permission=self.perm_change)
+        tup.save()
+
+        reload_test_users(self)
+
+        request = HttpRequest()
+        setattr(request, 'user', self.user)
+        request.META['SERVER_NAME'] = 'beedesk.com'
+        request.META['SERVER_PORT'] = 80
+        self.request = request
+    '''
+    def test_P(self):
+        p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'})
+        self.assertTrue(p.check(self.request, pk=self.content1.pk))
+
+        p = P(self.get_perm_code(self.perm_delete), fieldlookups_kwargs={'pk': 'pk'})
+        self.assertTrue(p.check(self.request, pk=self.content2.pk))'''
+
+    def test_P(self):
+        p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'})
+        self.assertTrue(p.check(self.request, pk=self.content1.pk))
+        self.assertTrue(p.check(self.request, pk=self.content2.pk))
+
+        p = P(self.get_perm_code(self.perm_delete), fieldlookups_kwargs={'pk': 'pk'})
+        self.assertTrue(p.check(self.request, pk=self.content1.pk))
+        self.assertFalse(p.check(self.request, pk=self.content2.pk))
+
+    def test_P_and(self):
+        p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'}) & \
+            P(self.get_perm_code(self.perm_delete), fieldlookups_kwargs={'pk': 'pk'})
+        self.assertTrue(p.check(self.request, pk=self.content1.pk))
+        self.assertFalse(p.check(self.request, pk=self.content2.pk))
+
+        p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'}) & \
+            P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'})
+        self.assertFalse(p.check(self.request, pk=self.content1.pk))
+
+    def test_P_or(self):
+        p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'}) | \
+            P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'})
+        self.assertTrue(p.check(self.request, pk=self.content1.pk))
+
+        p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'}) | \
+            P(self.get_perm_code(self.perm_delete), fieldlookups_kwargs={'pk': 'pk'})
+        self.assertTrue(p.check(self.request, pk=self.content1.pk))
+        self.assertTrue(p.check(self.request, pk=self.content2.pk))
+
+        p = P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'}) | \
+            P('auth.falsefalseperm_group', fieldlookups_kwargs={'pk': 'pk'})
+        self.assertFalse(p.check(self.request, pk=self.content1.pk))
+
+    def test_P_complex(self):
+        p = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'}) | \
+            (P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'}) &
+             P('admin.change_all'))
+        self.assertTrue(p.check(self.request, pk=self.content1.pk))
+        self.assertTrue(p.check(self.request, pk=self.content2.pk))
+
+        p = (P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'}) |
+             P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'})) & \
+            P('admin.change_all')
+        self.assertFalse(p.check(self.request, pk=self.content1.pk))
+        self.assertFalse(p.check(self.request, pk=self.content2.pk))
+
+        p1 = P(self.get_perm_code(self.perm_change), fieldlookups_kwargs={'pk': 'pk'})
+        p2 = P(self.get_perm_code(self.perm_delete), fieldlookups_kwargs={'pk': 'pk'})
+        p3 = P('auth.falseperm_group', fieldlookups_kwargs={'pk': 'pk'})
+        p4 = P('auth.falsefalseperm_group', fieldlookups_kwargs={'pk': 'pk'})
+        self.assertTrue(p1.check(self.request, pk=self.content1.pk))
+        self.assertTrue(p2.check(self.request, pk=self.content1.pk))
+        self.assertFalse(p3.check(self.request, pk=self.content1.pk))
+        self.assertFalse(p4.check(self.request, pk=self.content1.pk))
+
+        p = (p1 | p3) & (p2 | p4)
+        self.assertTrue(p.check(self.request, pk=self.content1.pk))
+
+        p = (p1 & p3) | (p2 & p4)
+        self.assertFalse(p.check(self.request, pk=self.content1.pk))
+
+        p = (p1 & p2) | (p3 & p4)
+        self.assertTrue(p.check(self.request, pk=self.content1.pk))
+
+        p = (p1 & p3) | (p2 & p4) | p1
+        self.assertTrue(p.check(self.request, pk=self.content1.pk))

--- a/trusts/tests.py
+++ b/trusts/tests.py
@@ -169,14 +169,14 @@ class DecoratorsTest(TestCase):
 
         create_test_users(self)
 
+        self.request = HttpRequest()
+        setattr(self.request, 'user', self.user)
+        self.request.META['SERVER_NAME'] = 'beedesk.com'
+        self.request.META['SERVER_PORT'] = 80
+
     def test_permission_required(self):
         self.group = Group(name='Group A')
         self.group.save()
-
-        request = HttpRequest()
-        setattr(request, 'user', self.user)
-        request.META['SERVER_NAME'] = 'beedesk.com'
-        request.META['SERVER_PORT'] = 80
 
         # test a) has_perms() == False
         mock = Mock(return_value='Response')
@@ -188,7 +188,7 @@ class DecoratorsTest(TestCase):
             fieldlookups_kwargs={'pk': 'pk'},
             raise_exception=False
         )(mock)
-        response = decorated_func(request, pk=self.group.pk)
+        response = decorated_func(self.request, pk=self.group.pk)
 
         self.assertFalse(mock.called)
         self.assertTrue(response.status_code, 403)
@@ -208,10 +208,10 @@ class DecoratorsTest(TestCase):
             'auth.read_group',
             fieldlookups_kwargs={'pk': 'pk'}
         )(mock)
-        response = decorated_func(request, pk=self.group.pk)
+        response = decorated_func(self.request, pk=self.group.pk)
 
         self.assertTrue(mock.called)
-        mock.assert_called_with(request, pk=self.group.pk)
+        mock.assert_called_with(self.request, pk=self.group.pk)
         self.assertEqual(response, 'Response')
         self.assertEqual(has_perms.call_args[0][0], ('auth.read_group',))
         filter = has_perms.call_args[0][1]
@@ -223,11 +223,6 @@ class DecoratorsTest(TestCase):
         self.group = Group(name='Group B')
         self.group.save()
 
-        request = HttpRequest()
-        setattr(request, 'user', self.user)
-        request.META['SERVER_NAME'] = 'beedesk.com'
-        request.META['SERVER_PORT'] = 80
-
         # test a) has_perms() == False, single P used
         mock = Mock(return_value='Response')
         has_perms = Mock(return_value=False)
@@ -237,7 +232,7 @@ class DecoratorsTest(TestCase):
             P('auth.read_group', fieldlookups_kwargs={'pk': 'pk'}),
             raise_exception=False
         )(mock)
-        response = decorated_func(request, pk=self.group.pk)
+        response = decorated_func(self.request, pk=self.group.pk)
 
         self.assertFalse(mock.called)
         self.assertTrue(response.status_code, 403)
@@ -258,10 +253,10 @@ class DecoratorsTest(TestCase):
             P('auth.add_group', fieldlookups_kwargs={'pk': 'pk'}),
             raise_exception=False
         )(mock)
-        response = decorated_func(request, pk=self.group.pk)
+        response = decorated_func(self.request, pk=self.group.pk)
 
         self.assertTrue(mock.called)
-        mock.assert_called_with(request, pk=self.group.pk)
+        mock.assert_called_with(self.request, pk=self.group.pk)
         self.assertEqual(response, 'Response')
         self.assertEqual(has_perms.call_args[0][0], ('auth.add_group',))
         filter = has_perms.call_args[0][1]


### PR DESCRIPTION
Currently, `django-trusts` supports permission check with the following syntax:

```
from trusts.decorators import permission_required
from app.models import Xyz

@permission_required('app.change_xyz', fieldlookups_kwargs={'pk': 'xyz_id'})
def edit_xyz_view(request, xyz_id):
  # ...
  pass
```

And, the goal is to improve the syntax to allow for union ("|") and intersect ("+").

```
from trusts.decorators import permission_required, P, K
from app.models import Xyz

@permission_required(
      P('app.moderate_xyz', pk=K('xyz_id')) 
    | P('app.update_xyz:own', pk=K('xyz_id'))
)
def edit_xyz_view(request, xyz_id):
  # ...
  pass
```

Where `K` for `kwargs`, which works like combined `fieldlookups_kwargs`,  `fieldlookups_getparams` and `fieldlookups_postparams` in existing `permission_required` method. Those three param should still be supported, in case there is duplication among the lookups.

Where `P` should work somewhat similar to Q() in QuerySet. https://docs.djangoproject.com/es/1.9/topics/db/queries/#complex-lookups-with-q-objects

It should support Union `|` and Intersect `&` operators.

---

Moving repo for issue #2.
