### PR TITLE
Modernize Python 3 support, packaging, Django 6.1, and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: tests (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install package and Django 6.1
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "Django>=6.1,<6.2" coverage
+          python -m pip install -e .
+      - name: Authorization tests
+        run: |
+          coverage run -m tests.runtests
+          coverage report
+      - name: Fresh migrate
+        run: python -m django migrate --noinput --settings=tests.settings
+
+  package:
+    name: package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+          twine check dist/*
+      - name: Install wheel and import
+        run: |
+          python -m pip install "Django>=6.1,<6.2"
+          python -m pip install dist/django_trusts-*.whl
+          python -c "import django; import os; os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.settings'); import sys; sys.path.insert(0, '.'); django.setup(); import trusts; from trusts.models import Trust; from trusts.backends import TrustModelBackend; print('imported', trusts.ENTITY_MODEL_NAME, Trust, TrustModelBackend)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           coverage report
       - name: Fresh migrate
         run: python -m django migrate --noinput --settings=tests.settings
+      - name: Legacy database upgrade
+        run: python scripts/verify-legacy-upgrade.py
 
   package:
     name: package
@@ -46,8 +48,12 @@ jobs:
           python -m pip install --upgrade pip build twine
           python -m build
           twine check dist/*
-      - name: Install wheel and import
+      - name: Install wheel and import from outside the checkout
+        env:
+          PYTHONPATH: ""
         run: |
           python -m pip install "Django>=6.1,<6.2"
           python -m pip install dist/django_trusts-*.whl
-          python -c "import django; import os; os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.settings'); import sys; sys.path.insert(0, '.'); django.setup(); import trusts; from trusts.models import Trust; from trusts.backends import TrustModelBackend; print('imported', trusts.ENTITY_MODEL_NAME, Trust, TrustModelBackend)"
+          WORK="$(mktemp -d)"
+          cd "$WORK"
+          python "${GITHUB_WORKSPACE}/scripts/verify-wheel-install.py" --checkout "${GITHUB_WORKSPACE}"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .Python
 env/
 venv/
+.venv/
 build/
 develop-eggs/
 dist/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,8 @@
-recursive-include trusts *
 include LICENSE
 include README.md
 include requirements.txt
-
+include migrates.md
+include pyproject.toml
+recursive-include trusts *
+global-exclude __pycache__
+global-exclude *.py[cod]

--- a/README.md
+++ b/README.md
@@ -50,13 +50,16 @@ Test
 python -m pip install "Django>=6.1,<6.2" coverage
 python -m pip install -e .
 python -m tests.runtests
+python scripts/verify-legacy-upgrade.py
 ```
 
-CI is GitHub Actions (`.github/workflows/ci.yml`): authorization tests on
-Python 3.12, 3.13, and 3.14 with Django 6.1, plus an sdist/wheel build and
-install check. Those job names (`tests (Python 3.12)`, `tests (Python 3.13)`,
-`tests (Python 3.14)`, `package`) are the current required-status candidates.
-Do not treat a removed Travis check as a stand-in green status.
+CI is GitHub Actions (`.github/workflows/ci.yml`): authorization tests, a
+fresh migrate, and the legacy-upgrade script on Python 3.12, 3.13, and 3.14
+with Django 6.1. The `package` job (Python 3.12 only) builds an sdist/wheel
+and imports it from a temporary directory so the source tree cannot satisfy
+the import. Job names: `tests (Python 3.12)`, `tests (Python 3.13)`,
+`tests (Python 3.14)`, `package`. Do not treat a removed Travis check as a
+stand-in green status.
 
 Development version
 -------------------

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Django Trusts
 -------------
 
-[![Docs](https://readthedocs.org/projects/django-trusts/badge/)](http://django-trusts.readthedocs.org) [![Coverage](https://coveralls.io/repos/github/beedesk/django-trusts/badge.svg?branch=master)](https://coveralls.io/github/beedesk/django-trusts?branch=master) [![Version](https://badge.fury.io/py/django-trusts.svg)](https://pypi.python.org/pypi/django-trusts)
+[![Docs](https://readthedocs.org/projects/django-trusts/badge/)](http://django-trusts.readthedocs.org) [![CI](https://github.com/django-trusts/django-trusts/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/django-trusts/django-trusts/actions/workflows/ci.yml)
 
 Django authorization add-on for multiple organizations and object-level permission settings
 
@@ -14,28 +14,55 @@ A ``trust`` is a relationship whereby content access is permitted by the creator
 
 ``django-trusts`` also strives to be a **scalable** solution. Permissions checking is offloaded to the database by design, and the implementation minimizes database hits. Permissions are cached per ``trust`` for the lifecycle of ``request user``. If a project's request lifecycle resolves most checked content to one or few ``trusts``, which should be very typically the case, this design should be a winner in term of performance. Permissions checking is done against an individual content or a ``QuerySet``.
 
-``django-trusts`` supports Django's builtins User models ``has_perms()`` / ``has_perms()`` and does not provides any in-addition.
+``django-trusts`` supports Django's builtins User models ``has_perm()`` / ``has_perms()`` and does not provides any in-addition.
 
 Read more: http://django-trusts.readthedocs.org/en/latest/
+
+Supported versions
+------------------
+
+The `1.0.0.dev0` development line requires **Python 3.12–3.14** and **Django 6.1**.
+Sources checked on 2026-09-07 and the rationale are in
+[docs/support-matrix.md](docs/support-matrix.md).
+
+This is not a published PyPI release. Install from a local checkout or sdist/wheel
+built from this tree.
+
+```
+python -m pip install "Django>=6.1,<6.2"
+python -m pip install .
+```
+
+Add `trusts` to `INSTALLED_APPS` and set:
+
+```
+AUTHENTICATION_BACKENDS = (
+    'trusts.backends.TrustModelBackend',
+)
+```
+
+API and compatibility notes for this modernization are in [migrates.md](migrates.md).
 
 Test
 ----
 
-To run unit tests:
+```
+python -m pip install "Django>=6.1,<6.2" coverage
+python -m pip install -e .
+python -m tests.runtests
+```
 
-```
-pip install virtualenv
-virtualenv venv/
-source venv/bin/activate
-python setup.py test
-```
+CI is GitHub Actions (`.github/workflows/ci.yml`): authorization tests on
+Python 3.12, 3.13, and 3.14 with Django 6.1, plus an sdist/wheel build and
+install check. Those job names (`tests (Python 3.12)`, `tests (Python 3.13)`,
+`tests (Python 3.14)`, `package`) are the current required-status candidates.
+Do not treat a removed Travis check as a stand-in green status.
 
 Development version
 -------------------
 
-The active package version is **1.0.0.dev0**. That is a development-line mark
-ahead of the planned Python/Django compatibility break, not a production 1.0
-release. See [docs/development-version.md](docs/development-version.md).
+The active package version is **1.0.0.dev0**. That is a development-line mark,
+not a production 1.0 release. See [docs/development-version.md](docs/development-version.md).
 
 Legacy baseline
 ---------------

--- a/docs/development-version.md
+++ b/docs/development-version.md
@@ -1,28 +1,38 @@
 # Development version 1.0.0.dev0
 
-The revived Trusts development line is now **1.0.0.dev0**. This is a
+The revived Trusts development line is **1.0.0.dev0**. This is a
 development-version mark only. It is not a production 1.0 release, not a PyPI
 publication, and not a claim that the declarative permission model has been
 validated.
 
 ## Why a new major version
 
-The last published package was **0.10.3** (`v0.10.3`). Upcoming Python 3 and
-modern Django work is expected to break compatibility with that historical
-stack (Python 2.7 / Django 1.8). Starting the next line at `1.0.0.dev0`
-records that planned break before those runtime changes land.
+The last published package was **0.10.3** (`v0.10.3`). The Python 3 and
+Django 6.1 work is a compatibility break with that historical stack
+(Python 2.7 / Django 1.8). The version was marked `1.0.0.dev0` in #18 before
+those runtime changes landed.
 
-This note does not change runtime support claims. Classifiers and
-`requirements.txt` still describe the historical environment until a later
-modernization PR updates them.
+## Current runtime claim
 
-## What this bump does not do
+See [support-matrix.md](support-matrix.md). Declared and CI-tested:
 
-- No API or method changes
-- No `migrates.md` entry (none is required)
+- Python 3.12, 3.13, 3.14
+- Django `>=6.1,<6.2`
+
+Package metadata lives in `pyproject.toml`. `setup.py` is a thin setuptools
+wrapper. Obsolete Python 2 classifiers and `six` / `funcsigs` / `mock` / `pbr`
+install dependencies are removed.
+
+API and method changes for the modernization are recorded in
+[../migrates.md](../migrates.md).
+
+## What this line still does not do
+
 - No final `1.0.0` tag or GitHub Release
+- No PyPI publication
 - No move or replacement of existing tags, including `v0.10.3` and
   `legacy-pre-modernization`
+- No permission-model redesign
 
 ## Preserved legacy source
 
@@ -42,12 +52,10 @@ version.
 
 ## Version sources
 
-| Location | Role | Previous | Now |
-| --- | --- | --- | --- |
-| `setup.py` | Authoritative package metadata | `0.10.3` | `1.0.0.dev0` |
-| `docs/source/conf.py` | Sphinx `version` / `release` | `0.9.4` (already stale vs 0.10.3) | `1.0.0.dev0` |
-| `trusts/__init__.py` | No `__version__` | — | unchanged |
-| `docs/legacy-baseline.md`, `docs/legacy/baseline.json` | Historical 0.10.3 record | `0.10.3` | preserved |
-
-No `pyproject.toml` or `setup.cfg` version field exists. Existing git tags were
-not moved.
+| Location | Role | Value |
+| --- | --- | --- |
+| `pyproject.toml` | Authoritative package metadata | `1.0.0.dev0` |
+| `setup.py` | Thin wrapper; no duplicate version field | defers to `pyproject.toml` |
+| `docs/source/conf.py` | Sphinx `version` / `release` | `1.0.0.dev0` |
+| `trusts/__init__.py` | No `__version__` | unchanged |
+| `docs/legacy-baseline.md`, `docs/legacy/baseline.json` | Historical 0.10.3 record | preserved |

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,8 +55,8 @@ Use ``Content`` ::
    from trusts.models import Content
 
    class Receipt(Content, models.Model):
-       account = models.ForeignKey(Account, null=True)
-       merchant = models.ForeignKey(Merchant, null=True)
+       account = models.ForeignKey(Account, null=True, on_delete=models.CASCADE)
+       merchant = models.ForeignKey(Merchant, null=True, on_delete=models.CASCADE)
        # ... other field
 
 Alternative 2
@@ -73,7 +73,7 @@ Use ``Junction`` ::
    # New Junction to model that is not under your control
    class GroupJunction(Junction, models.Model):
        # field name must be named as `content` and unique=True, null=False, blank=False
-       content = models.ForeignKey(django.contrib.auth.models.Group, unique=True, null=False, blank=False)
+       content = models.ForeignKey(django.contrib.auth.models.Group, unique=True, null=False, blank=False, on_delete=models.CASCADE)
 
 Permission Assignments
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -25,8 +25,11 @@ declares one matrix and tests it in CI.
 | Python | 3.12, 3.13, 3.14 (`requires-python >=3.12`) | Intersection of currently supported CPython and Django 6.1's official matrix. 3.10/3.11 remain in CPython security support but are not in Django 6.1's matrix. 3.15 is not a stable release yet. |
 | Django | `>=6.1,<6.2` (tested against 6.1.1) | Latest stable Django at implementation time, per #15. |
 
-CI runs the authorization tests and a package build/install check on each
-declared Python version with Django 6.1. See `.github/workflows/ci.yml`.
+CI (`.github/workflows/ci.yml`) runs authorization tests, a fresh migrate,
+and `scripts/verify-legacy-upgrade.py` on **each** declared Python version
+with Django 6.1. The `package` job (sdist/wheel build, `twine check`, and
+an out-of-checkout wheel import) runs on **Python 3.12** as a representative
+install of the declared range.
 
 ## What is intentionally not declared
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,0 +1,47 @@
+# Supported Python and Django matrix
+
+Recorded on **2026-09-07** while implementing #14 and the coordinated
+Django/CI work from #15. This is the current development-line claim for
+`1.0.0.dev0`. It is not a published PyPI release.
+
+A Python-only intermediate against Django 1.8 is not a supported or testable
+state: Django 1.8 does not install on current CPython, and the preserved
+implementation uses removed Django 1.8 APIs. The merged tree therefore
+declares one matrix and tests it in CI.
+
+## Sources checked at implementation time
+
+| Source | What it established | URL |
+| --- | --- | --- |
+| Django download page | Latest official Django is **6.1.1**. 6.1 mainstream support ends April 2027. Django 5.2 is the current LTS (extended support through April 2028). Django 4.2 LTS ended 2026-04-07. | https://www.djangoproject.com/download/ |
+| Django install FAQ (stable) | Django **6.1** officially supports **Python 3.12, 3.13, and 3.14** only. | https://docs.djangoproject.com/en/stable/faq/install/ |
+| Django 6.1 release notes | Same Python list; only the latest micro of each series is officially supported. | https://docs.djangoproject.com/en/6.1/releases/6.1/ |
+| CPython Developer's Guide | Supported CPython on 2026-09-07: 3.14 and 3.13 (bugfix), 3.12 / 3.11 / 3.10 (security). 3.15 is prerelease (first release scheduled 2026-10-01). 3.9 ended 2025-10-31. | https://devguide.python.org/versions/ |
+
+## Declared support
+
+| Component | Requirement | Rationale |
+| --- | --- | --- |
+| Python | 3.12, 3.13, 3.14 (`requires-python >=3.12`) | Intersection of currently supported CPython and Django 6.1's official matrix. 3.10/3.11 remain in CPython security support but are not in Django 6.1's matrix. 3.15 is not a stable release yet. |
+| Django | `>=6.1,<6.2` (tested against 6.1.1) | Latest stable Django at implementation time, per #15. |
+
+CI runs the authorization tests and a package build/install check on each
+declared Python version with Django 6.1. See `.github/workflows/ci.yml`.
+
+## What is intentionally not declared
+
+- **Django 5.2 LTS** is still in extended support. It was not added to this
+  first modernization matrix so the project does not maintain an extra
+  intermediate stack. Revisit if downstream projects need the LTS line.
+- **Python 3.10 / 3.11** are still in CPython security support but are not
+  official Django 6.1 runtimes.
+- **Python 3.15** is a prerelease as of this record.
+- The historical Python 2.7 / Django 1.8 stack is documented only in
+  [legacy-baseline.md](legacy-baseline.md). That snapshot is unchanged.
+
+## Historical requirements (not current)
+
+At `legacy-pre-modernization` (`20ef239`): Python 2.7 and `Django>=1.8,<1.9`,
+plus `six`, `funcsigs`, `mock`, `pbr`, `docutils`, and `wheel` as install
+requirements. Those compatibility packages are removed from the development
+line.

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -38,7 +38,7 @@ joined model. That is historical, not a new denial-widening.
 | `get_group_permissions` content path | Returns a permission queryset, not the string set `ModelBackend` uses; no dedicated assertion. |
 | Decorator `raise_exception=True` | Most decorator tests use `raise_exception=False`. |
 | `TRUSTS_ENTITY_MODEL` swap | Custom entity model is configurable but untested. |
-| Legacy SQLite/MySQL dump upgrade | Fresh `migrate` is in CI; a captured 0.10.3 database file is not. |
+| Captured production MySQL/Postgres dump | `scripts/verify-legacy-upgrade.py` upgrades a representative 0.10.3-shaped SQLite DB (`trusts.0001_initial` already recorded, historical table DDL). It is not a customer dump and does not replay Django 1.8 contrib tables. |
 | Admin / i18n surfaces | Registered, not exercised. |
 
 Do not treat a gap as license to widen access. New grants need an explicit

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -1,0 +1,45 @@
+# Authorization test coverage
+
+Recorded with the #14/#15 modernization. Existing tests were kept and
+extended. This is not a claim that the declarative permission model is
+complete.
+
+## Tests that must keep passing
+
+Denied access and organization isolation (a trust is the organization
+boundary):
+
+- `TrustContentTestMixin.test_user_not_in_group_has_no_perm`
+- `TrustContentTestMixin.test_has_perm_disallow_no_perm_content`
+- `TrustContentTestMixin.test_has_perm_disallow_no_perm_perm`
+- `TrustContentTestMixin.test_mixed_trust_queryset`
+- `TrustContentTestMixin.test_denied_access_without_grant` (added)
+- `TrustContentTestMixin.test_organization_isolation_denies_cross_trust_access` (added)
+- `TrustTest.test_own_condition_requires_settlor` (added; `:own` is settlor-only)
+- Role tests that a stronger role on one trust does not leak to another
+
+These run for `Content` subclasses, `Junction` content, and `Trust` as content
+where the mixin applies.
+
+## Known expected failure
+
+`TrustJunctionTestCase.test_read_permissions_added` remains
+`@unittest.expectedFailure`. Junctions do not add `read_*` permissions on the
+joined model. That is historical, not a new denial-widening.
+
+## Coverage gaps (not closed here)
+
+| Area | Why it is a gap |
+| --- | --- |
+| Anonymous request users | Settlor-anonymous is rejected; object-level anonymous grants are not specified. |
+| Superuser short-circuit | Django's `ModelBackend` still treats superusers as having all perms; no extra Trusts test. |
+| Nested / inherited trusts | `Trust.trust` is a parent pointer with a readonly check; no recursive ACL evaluation (out of scope). |
+| `has_perm` without `obj` | Falls through to Django model-level perms; only lightly covered via role tests. |
+| `get_group_permissions` content path | Returns a permission queryset, not the string set `ModelBackend` uses; no dedicated assertion. |
+| Decorator `raise_exception=True` | Most decorator tests use `raise_exception=False`. |
+| `TRUSTS_ENTITY_MODEL` swap | Custom entity model is configurable but untested. |
+| Legacy SQLite/MySQL dump upgrade | Fresh `migrate` is in CI; a captured 0.10.3 database file is not. |
+| Admin / i18n surfaces | Registered, not exercised. |
+
+Do not treat a gap as license to widen access. New grants need an explicit
+test.

--- a/migrates.md
+++ b/migrates.md
@@ -1,0 +1,159 @@
+# Migration record (1.0.0.dev0 Python/Django modernization)
+
+This record covers API and method changes in the coordinated #14/#15
+modernization. Authorization semantics are intended to be preserved. This is
+not a permission-model redesign.
+
+## No change to these public call sites
+
+These keep their previous signatures and intended allow/deny behavior:
+
+- `User.has_perm` / `User.has_perms` via `trusts.backends.TrustModelBackend`
+- `trusts.decorators.permission_required`, `P`, `K`, `G`, `O`
+- `Trust.objects.get_or_create_settlor_default`, `get_root`,
+  `filter_by_content`, `filter_by_user_perm`
+- `Content` / `Junction` subclassing, role `Meta` options, management commands
+  `create_trust_root` and `update_roles_permissions`
+
+Runtime requirements changed (Python 2.7 / Django 1.8 → Python ≥3.12 /
+Django 6.1). That is a compatibility break, not a Trusts method rename.
+
+## Changes
+
+### 1. `ForeignKey` fields now require `on_delete=CASCADE`
+
+| | |
+| --- | --- |
+| Previous | Django 1.8 `ForeignKey(...)` with implicit cascade-on-delete. |
+| New | Every Trusts `ForeignKey` (models and historical `0001_initial`) declares `on_delete=models.CASCADE`. |
+| Replacement | Same field, explicit argument matching the 1.8 default. |
+| Affected | `Content.trust`, `Trust.settlor` / `Trust.trust`, `RolePermission`, `TrustUserPermission`, `Junction.trust`. Downstream `ForeignKey`s on project models also need `on_delete` (Django, not Trusts). |
+| Authorization | Delete still cascades as in 1.8. Not switched to Django 6.1 `DB_CASCADE` (that would skip `pre_delete` / `post_delete`). |
+
+Migration-bot checklist:
+
+- [ ] Find project `ForeignKey` / `OneToOneField` declarations missing `on_delete`.
+- [ ] Set `on_delete=models.CASCADE` unless a different policy is documented.
+- [ ] Do not add a new Trusts schema migration solely for this; `0001_initial` was updated in place so already-applied installs keep the same migration name.
+- [ ] Verify delete of a `Trust` / user still cascades related trustee rows.
+
+### 2. `P.__unicode__` removed; `__str__` is the Python 3 display method
+
+| | |
+| --- | --- |
+| Previous | `P.__unicode__` returned `self.perm` (attribute did not exist; leaf `repr` was already broken) or `'P object'`. |
+| New | `P.__str__` returns `self._perm` or `'P object'`. `__unicode__` is gone. |
+| Replacement | `str(p)` / `repr(p)`. |
+| Affected | Debug logging only. Permission evaluation uses `P.solve`, not stringification. |
+| Authorization | None. |
+
+Migration-bot checklist:
+
+- [ ] Replace `P.__unicode__` / `.unicode()` calls with `str(...)`.
+- [ ] Re-run decorator expression tests.
+
+### 3. Django user anonymity is a property
+
+| | |
+| --- | --- |
+| Previous | `user.is_anonymous()` (Django 1.8 method). |
+| New | `user.is_anonymous` (Django ≥1.10 property). Used by `TrustManager.get_or_create_settlor_default` and `TrustModelBackendMixin`. |
+| Replacement | Property access. Trusts' public method signatures are unchanged. |
+| Affected | Internal checks only. Anonymous settlors remain unsupported (`ValueError`). |
+| Authorization | Same reject of anonymous settlors. Anonymous users still fall through to `ModelBackend`. |
+
+Migration-bot checklist:
+
+- [ ] Replace project `user.is_anonymous()` / `user.is_authenticated()` calls with property access if still on the old form.
+- [ ] Confirm anonymous users cannot obtain trust-scoped grants.
+
+### 4. `create_trust_root` is idempotent; `apps=` is no longer a command option
+
+| | |
+| --- | --- |
+| Previous | Always inserted the root row; a second run raised `IntegrityError`. `call_command('create_trust_root', apps=apps)` passed historical models. |
+| New | Returns the existing root when `pk` already exists. Django 6.1 rejects unknown command options, so `0001_initial` calls `create_root_trust` with `apps.get_model(...)` instead of `call_command(..., apps=apps)`. |
+| Replacement | `create_root_trust(Trust, pk, settlor, title)` or `manage.py create_trust_root`. |
+| Affected | Tests and `0001_initial` `RunPython`. Project code that passed `apps=` to the command must stop doing so. |
+| Authorization | Does not create extra roots or change `TRUSTS_ROOT_PK`. |
+
+Migration-bot checklist:
+
+- [ ] You may run `create_trust_root` on an upgraded database; it is a no-op when the root exists.
+- [ ] Confirm a single root (`Trust.objects.filter(trust=F('id')).count() == 1`).
+
+### 5. Internal Django/Python compatibility (same Trusts signatures)
+
+These are required for Django 6.1 / Python 3 and do not change Trusts call
+signatures:
+
+| Previous | New |
+| --- | --- |
+| `django.utils.translation.ugettext_lazy` | `gettext_lazy` |
+| `field.rel` / `field.rel.to` | `field.remote_field` / `field.remote_field.model` |
+| `dict.iteritems()` | `dict.items()` |
+| `six.string_types` / `django.utils.six` | `str` |
+| `from mock import Mock` | `unittest.mock` |
+| `urllib` / `urlparse` (Python 2) | `urllib.parse` |
+| `django.utils.decorators.available_attrs` | `functools.wraps` defaults |
+| `django.contrib.auth.views.redirect_to_login` | unchanged (still in `auth.views`) |
+| `default_app_config` | `trusts.apps.AppConfig` discovery |
+| `ManyToManyField(..., null=True)` | `null` dropped (it had no effect) |
+| `connection.creation.sql_create_model` (tests) | `schema_editor.create_model` |
+
+Bugfixes included because the previous names crashed on modern Python:
+
+- `get_group_model()` now uses `GROUP_MODEL_NAME` (was undefined `GROUP_MODEL`).
+- `get_*_model()` helpers import `ImproperlyConfigured`.
+- `permission_condition_met` iterates `obj` (was `hasattr(trusts, ...)`, a `NameError`). Iterable object lists are now evaluated item-by-item, matching the QuerySet path. Single model instances are unchanged.
+- `ReadonlyFieldsMixin` snapshots ForeignKey column values (`trust_id`, `settlor_id`) instead of following the relation. Django 6.1 fetch modes would otherwise recurse on the self-referential root trust. The readonly rule is unchanged: `trust` and `settlor` still cannot be reassigned after create.
+
+Authorization implication of the `permission_condition_met` fix: a caller who
+passed a non-QuerySet iterable previously crashed. They now get an all-must-match
+result. No change for the supported QuerySet and single-object paths.
+
+## Migration history
+
+- Historical migration `trusts.0001_initial` is kept. `on_delete=CASCADE` was
+  added in place so Django 6.1 can load it. That matches the implicit 1.8
+  default and does not change the database schema.
+- Primary keys remain `AutoField`. `AppConfig.default_auto_field` is set to
+  `django.db.models.AutoField` so new Trusts models do not switch to
+  `BigAutoField`.
+- `unique_together` is kept (still valid in Django 6.1) to avoid a new schema
+  migration.
+
+### Fresh database
+
+```
+python -m django migrate --settings=tests.settings
+```
+
+Applies `0001_initial` and creates the root trust when `TRUSTS_CREATE_ROOT`
+is true (default).
+
+### Upgrade of a representative legacy database
+
+If `django_migrations` already contains `trusts 0001_initial`:
+
+1. Install the modernized package on Python ≥3.12 with Django 6.1.
+2. Do **not** fake or re-run `0001_initial`.
+3. Run `migrate` to apply any other app migrations. Trusts adds no `0002`.
+4. Run `create_trust_root` if the root row is missing (idempotent).
+5. Re-run authorization tests, including denied access and isolation.
+
+No intermediate Trusts migration is required. Project models still need
+Django's own 1.8→6.1 upgrade path (removed APIs, `on_delete`, middleware,
+auto fields).
+
+## Migration-bot summary
+
+- [ ] Locate `ForeignKey` without `on_delete` and `user.is_anonymous()` call sites.
+- [ ] Update those to CASCADE (unless documented otherwise) and property access.
+- [ ] Replace `P.__unicode__` with `str`.
+- [ ] Confirm `INSTALLED_APPS` includes `trusts` and
+      `AUTHENTICATION_BACKENDS` includes `trusts.backends.TrustModelBackend`.
+- [ ] `pip install` the modernized package; do not install `six` / `funcsigs` /
+      `mock` / `pbr` for Trusts itself.
+- [ ] Migrate a fresh DB and an already-applied `0001_initial` DB as above.
+- [ ] Verify allow, deny, `:own`, and cross-organization isolation tests.

--- a/migrates.md
+++ b/migrates.md
@@ -116,7 +116,9 @@ result. No change for the supported QuerySet and single-object paths.
 
 - Historical migration `trusts.0001_initial` is kept. `on_delete=CASCADE` was
   added in place so Django 6.1 can load it. That matches the implicit 1.8
-  default and does not change the database schema.
+  default and does not change the database schema. `Trust.trust.related_name`
+  in that migration uses the same `%(app_label)s_%(class)s_content` template
+  as the model (the rendered `trusts_trust_content` value is unchanged).
 - Primary keys remain `AutoField`. `AppConfig.default_auto_field` is set to
   `django.db.models.AutoField` so new Trusts models do not switch to
   `BigAutoField`.
@@ -134,17 +136,26 @@ is true (default).
 
 ### Upgrade of a representative legacy database
 
-If `django_migrations` already contains `trusts 0001_initial`:
+`scripts/verify-legacy-upgrade.py` is the executable check. It:
 
-1. Install the modernized package on Python ≥3.12 with Django 6.1.
-2. Do **not** fake or re-run `0001_initial`.
-3. Run `migrate` to apply any other app migrations. Trusts adds no `0002`.
-4. Run `create_trust_root` if the root row is missing (idempotent).
-5. Re-run authorization tests, including denied access and isolation.
+1. Applies Django contrib migrations only.
+2. Creates Trusts tables from `scripts/legacy/trusts_0001_sqlite.sql`
+   (0.10.3 / `0001_initial` field layout).
+3. Records `trusts.0001_initial` as already applied. It does **not** fake
+   or re-run that migration.
+4. Seeds a root row and two organizations.
+5. Runs modern `migrate` and asserts the Trusts plan stays empty and the
+   applied set remains `{0001_initial}`.
+6. Checks the root row plus allow/deny/isolation on `Trust` content.
 
-No intermediate Trusts migration is required. Project models still need
-Django's own 1.8→6.1 upgrade path (removed APIs, `on_delete`, middleware,
-auto fields).
+```
+python scripts/verify-legacy-upgrade.py
+```
+
+That is a representative Trusts upgrade, not a captured production dump
+and not a full Django 1.8→6.1 contrib-schema upgrade. Project models still
+need Django's own 1.8→6.1 path (removed APIs, `on_delete`, middleware,
+auto fields). No intermediate Trusts migration is required.
 
 ## Migration-bot summary
 
@@ -155,5 +166,6 @@ auto fields).
       `AUTHENTICATION_BACKENDS` includes `trusts.backends.TrustModelBackend`.
 - [ ] `pip install` the modernized package; do not install `six` / `funcsigs` /
       `mock` / `pbr` for Trusts itself.
-- [ ] Migrate a fresh DB and an already-applied `0001_initial` DB as above.
+- [ ] Migrate a fresh DB (`python -m django migrate --settings=tests.settings`).
+- [ ] Run `python scripts/verify-legacy-upgrade.py` for the already-applied `0001_initial` path.
 - [ ] Verify allow, deny, `:own`, and cross-organization isolation tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,59 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "django-trusts"
+version = "1.0.0.dev0"
+description = "Django authorization add-on for multiple organizations and object-level permission settings"
+readme = "README.md"
+license = "BSD-2-Clause"
+authors = [
+    { name = "Thomas Yip", email = "thomasleaf@gmail.com" },
+]
+requires-python = ">=3.12"
+dependencies = [
+    "Django>=6.1,<6.2",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Framework :: Django",
+    "Framework :: Django :: 6.1",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: System Administrators",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Topic :: Software Development :: Libraries",
+]
+keywords = ["django", "authorization", "permissions", "organizations"]
+
+[project.urls]
+Homepage = "https://github.com/django-trusts/django-trusts"
+Repository = "https://github.com/django-trusts/django-trusts"
+Issues = "https://github.com/django-trusts/django-trusts/issues"
+Documentation = "https://django-trusts.readthedocs.org/en/latest/"
+"Legacy baseline" = "https://github.com/django-trusts/django-trusts/blob/master/docs/legacy-baseline.md"
+"Support matrix" = "https://github.com/django-trusts/django-trusts/blob/master/docs/support-matrix.md"
+
+[project.optional-dependencies]
+test = [
+    "coverage>=7.0",
+]
+
+[tool.setuptools]
+include-package-data = true
+zip-safe = false
+
+[tool.setuptools.packages.find]
+include = ["trusts*"]
+exclude = ["tests*", "docs*", "scripts*"]
+
+[tool.setuptools.package-data]
+trusts = ["*"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,2 @@
-Django>=1.8,<1.9
-docutils>=0.12
-funcsigs>=0.4
-mock>=1.3.0
-pbr>=1.8.1
-six>=1.10.0
-wheel>=0.24.0
+# Runtime requirements. pyproject.toml is authoritative.
+Django>=6.1,<6.2

--- a/scripts/legacy/trusts_0001_sqlite.sql
+++ b/scripts/legacy/trusts_0001_sqlite.sql
@@ -1,0 +1,52 @@
+-- Representative django-trusts 0.10.3 / pre-modernization SQLite schema.
+-- Matches trusts.0001_initial field layout at legacy-pre-modernization.
+-- Django 1.8 CASCADE was implicit and Python-level; this SQL has no
+-- ON DELETE CASCADE clauses, same as the historical table.
+
+CREATE TABLE "trusts_trust" (
+    "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "title" varchar(40) NOT NULL,
+    "settlor_id" integer NULL REFERENCES "auth_user" ("id") DEFERRABLE INITIALLY DEFERRED,
+    "trust_id" integer NOT NULL REFERENCES "trusts_trust" ("id") DEFERRABLE INITIALLY DEFERRED
+);
+CREATE UNIQUE INDEX "trusts_trust_settlor_id_title_6e2b0c8a_uniq"
+    ON "trusts_trust" ("settlor_id", "title");
+
+CREATE TABLE "trusts_trust_groups" (
+    "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "trust_id" integer NOT NULL REFERENCES "trusts_trust" ("id") DEFERRABLE INITIALLY DEFERRED,
+    "group_id" integer NOT NULL REFERENCES "auth_group" ("id") DEFERRABLE INITIALLY DEFERRED
+);
+CREATE UNIQUE INDEX "trusts_trust_groups_trust_id_group_id_uniq"
+    ON "trusts_trust_groups" ("trust_id", "group_id");
+
+CREATE TABLE "trusts_trustuserpermission" (
+    "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "entity_id" integer NOT NULL REFERENCES "auth_user" ("id") DEFERRABLE INITIALLY DEFERRED,
+    "permission_id" integer NOT NULL REFERENCES "auth_permission" ("id") DEFERRABLE INITIALLY DEFERRED,
+    "trust_id" integer NOT NULL REFERENCES "trusts_trust" ("id") DEFERRABLE INITIALLY DEFERRED
+);
+CREATE UNIQUE INDEX "trusts_trustuserpermission_trust_id_entity_id_permission_id_uniq"
+    ON "trusts_trustuserpermission" ("trust_id", "entity_id", "permission_id");
+
+CREATE TABLE "trusts_role" (
+    "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" varchar(80) NOT NULL UNIQUE
+);
+
+CREATE TABLE "trusts_role_groups" (
+    "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "role_id" integer NOT NULL REFERENCES "trusts_role" ("id") DEFERRABLE INITIALLY DEFERRED,
+    "group_id" integer NOT NULL REFERENCES "auth_group" ("id") DEFERRABLE INITIALLY DEFERRED
+);
+CREATE UNIQUE INDEX "trusts_role_groups_role_id_group_id_uniq"
+    ON "trusts_role_groups" ("role_id", "group_id");
+
+CREATE TABLE "trusts_rolepermission" (
+    "id" integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "managed" bool NOT NULL,
+    "permission_id" integer NOT NULL REFERENCES "auth_permission" ("id") DEFERRABLE INITIALLY DEFERRED,
+    "role_id" integer NOT NULL REFERENCES "trusts_role" ("id") DEFERRABLE INITIALLY DEFERRED
+);
+CREATE UNIQUE INDEX "trusts_rolepermission_role_id_permission_id_uniq"
+    ON "trusts_rolepermission" ("role_id", "permission_id");

--- a/scripts/verify-legacy-upgrade.py
+++ b/scripts/verify-legacy-upgrade.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Upgrade a representative pre-modernization Trusts SQLite database.
+
+Builds a 0.10.3-shaped database:
+
+1. Apply Django contrib migrations only (auth/contenttypes/sessions/admin).
+2. Create Trusts tables from the historical 0001 SQLite DDL.
+3. Record ``trusts.0001_initial`` as already applied (as a 0.10.3 install
+   would have).
+4. Seed a root trust plus two organizations with allow/deny grants.
+5. Run modern ``migrate`` without faking or reapplying Trusts 0001.
+6. Smoke-check the root row and organization isolation.
+
+This is not a captured production dump and does not replay a full Django
+1.8→6.1 contrib upgrade. It is the Trusts-specific already-applied-0001
+path required by #15.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SQL_PATH = ROOT / 'scripts' / 'legacy' / 'trusts_0001_sqlite.sql'
+
+
+def _configure(db_path: Path) -> None:
+    from django.conf import settings
+
+    settings.configure(
+        SECRET_KEY='legacy-upgrade-smoke',
+        USE_TZ=True,
+        DEFAULT_AUTO_FIELD='django.db.models.AutoField',
+        INSTALLED_APPS=[
+            'django.contrib.contenttypes',
+            'django.contrib.auth',
+            'django.contrib.sessions',
+            'django.contrib.admin',
+            'trusts',
+        ],
+        AUTHENTICATION_BACKENDS=['trusts.backends.TrustModelBackend'],
+        DATABASES={
+            'default': {
+                'ENGINE': 'django.db.backends.sqlite3',
+                'NAME': str(db_path),
+            }
+        },
+    )
+
+
+def _applied_trusts(connection) -> set[str]:
+    from django.db.migrations.recorder import MigrationRecorder
+
+    recorder = MigrationRecorder(connection)
+    return {name for app, name in recorder.applied_migrations() if app == 'trusts'}
+
+
+def _trusts_plan(connection):
+    from django.db.migrations.executor import MigrationExecutor
+
+    executor = MigrationExecutor(connection)
+    plan = executor.migration_plan(executor.loader.graph.leaf_nodes())
+    return [(migration.app_label, migration.name, backwards) for migration, backwards in plan
+            if migration.app_label == 'trusts']
+
+
+def main() -> int:
+    if not SQL_PATH.is_file():
+        raise SystemExit('Missing historical DDL: %s' % SQL_PATH)
+
+    with tempfile.TemporaryDirectory(prefix='django-trusts-legacy-upgrade-') as tmp:
+        db_path = Path(tmp) / 'legacy.sqlite3'
+        _configure(db_path)
+
+        import django
+        from django.core.management import call_command
+        from django.db import connection
+
+        django.setup()
+
+        # 1. Contrib schema only. Do not apply trusts.0001_initial.
+        call_command('migrate', 'contenttypes', verbosity=0, interactive=False)
+        call_command('migrate', 'auth', verbosity=0, interactive=False)
+        call_command('migrate', 'sessions', verbosity=0, interactive=False)
+        call_command('migrate', 'admin', verbosity=0, interactive=False)
+
+        if _applied_trusts(connection):
+            raise SystemExit('Trusts migrations were applied before the legacy seed.')
+
+        # 2–3. Historical tables + already-applied 0001 record.
+        connection.close()
+        raw = sqlite3.connect(db_path)
+        try:
+            raw.executescript(SQL_PATH.read_text())
+            raw.execute(
+                'INSERT INTO django_migrations (app, name, applied) VALUES (?, ?, ?)',
+                ('trusts', '0001_initial', datetime.now(timezone.utc).isoformat()),
+            )
+            raw.execute(
+                'INSERT INTO trusts_trust (id, title, settlor_id, trust_id) VALUES (1, ?, NULL, 1)',
+                ('In Trust We Trust',),
+            )
+            raw.commit()
+        finally:
+            raw.close()
+
+        if _applied_trusts(connection) != {'0001_initial'}:
+            raise SystemExit('Expected only trusts.0001_initial to be recorded after the seed.')
+
+        pending_before = _trusts_plan(connection)
+        if pending_before:
+            raise SystemExit('Modern tree wants extra Trusts migrations before upgrade: %s' % pending_before)
+
+        # 4. Seed organizations after Django can see the historical tables.
+        from django.contrib.auth.models import Permission, User
+        from django.contrib.contenttypes.models import ContentType
+        from trusts.models import Trust, TrustUserPermission
+
+        user_a = User.objects.create_user('org_a_user', 'a@example.com', 'pass')
+        user_b = User.objects.create_user('org_b_user', 'b@example.com', 'pass')
+        root = Trust.objects.get(pk=1)
+        org_a = Trust(settlor=user_a, title='Org A', trust=root)
+        org_a.save()
+        org_b = Trust(settlor=user_b, title='Org B', trust=root)
+        org_b.save()
+        child_a = Trust(settlor=user_a, title='Child A', trust=org_a)
+        child_a.save()
+        child_b = Trust(settlor=user_b, title='Child B', trust=org_b)
+        child_b.save()
+        denied = Trust(settlor=user_a, title='No Grant', trust=root)
+        denied.save()
+        denied_child = Trust(settlor=user_a, title='No Grant Child', trust=denied)
+        denied_child.save()
+
+        # 5. Modern migrate: must not reapply or fake Trusts 0001.
+        call_command('migrate', verbosity=1, interactive=False)
+        if _applied_trusts(connection) != {'0001_initial'}:
+            raise SystemExit('Trusts migration set changed during upgrade: %s' % _applied_trusts(connection))
+        pending_after = _trusts_plan(connection)
+        if pending_after:
+            raise SystemExit('Trusts migrations still pending after upgrade: %s' % pending_after)
+
+        # post_migrate creates Trust content types / default permissions.
+        change = Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Trust),
+            codename='change_trust',
+        )
+        TrustUserPermission(trust=org_a, entity=user_a, permission=change).save()
+        TrustUserPermission(trust=org_b, entity=user_b, permission=change).save()
+
+        user_a = User.objects.get(pk=user_a.pk)
+        user_b = User.objects.get(pk=user_b.pk)
+        child_a = Trust.objects.get(pk=child_a.pk)
+        child_b = Trust.objects.get(pk=child_b.pk)
+        denied_child = Trust.objects.get(pk=denied_child.pk)
+        root = Trust.objects.get(pk=1)
+
+        if root.trust_id != root.pk:
+            raise SystemExit('Root trust is not self-referential.')
+        if Trust.objects.filter(trust_id=1, id=1).count() != 1:
+            raise SystemExit('Expected a single root row.')
+
+        if not user_a.has_perm('trusts.change_trust', child_a):
+            raise SystemExit('Org A user was denied on Org A content.')
+        if user_a.has_perm('trusts.change_trust', child_b):
+            raise SystemExit('Org A user was allowed on Org B content.')
+        if not user_b.has_perm('trusts.change_trust', child_b):
+            raise SystemExit('Org B user was denied on Org B content.')
+        if user_b.has_perm('trusts.change_trust', child_a):
+            raise SystemExit('Org B user was allowed on Org A content.')
+        if user_a.has_perm('trusts.change_trust', denied_child):
+            raise SystemExit('User with no grant was allowed on isolated content.')
+        if user_b.has_perm('trusts.change_trust', denied_child):
+            raise SystemExit('Unrelated user was allowed on isolated content.')
+
+        print('legacy upgrade ok')
+        print('django', django.get_version())
+        print('db', db_path)
+        print('applied trusts migrations', sorted(_applied_trusts(connection)))
+        print('root', root.pk, root.title)
+        print('isolation allow/deny passed')
+    return 0
+
+
+if __name__ == '__main__':
+    os.chdir(ROOT)
+    sys.path.insert(0, str(ROOT))
+    sys.exit(main())

--- a/scripts/verify-wheel-install.py
+++ b/scripts/verify-wheel-install.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Import-smoke the installed django-trusts wheel from outside the checkout.
+
+This must not be run with the repository root as cwd or on sys.path. A
+passing result means trusts, Trust, and TrustModelBackend were loaded from
+the installed distribution, not the source tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--checkout',
+        required=True,
+        help='Absolute path to the repository checkout that must not be imported',
+    )
+    args = parser.parse_args()
+    checkout = Path(args.checkout).resolve()
+    cwd = Path.cwd().resolve()
+
+    if cwd == checkout or checkout in cwd.parents:
+        raise SystemExit(
+            'Refuse to run from the checkout (%s). cd to a temporary directory.' % cwd
+        )
+
+    leaked = []
+    for entry in sys.path:
+        if entry == '':
+            if cwd == checkout:
+                leaked.append("'' (cwd is the checkout)")
+            continue
+        try:
+            resolved = Path(entry).resolve()
+        except OSError:
+            continue
+        # Only the checkout root can shadow the installed `trusts` package.
+        if resolved == checkout:
+            leaked.append(entry)
+    if leaked:
+        raise SystemExit('Checkout leaked onto sys.path: %s' % leaked)
+
+    from django.conf import settings
+
+    settings.configure(
+        SECRET_KEY='wheel-import-smoke',
+        USE_TZ=True,
+        DEFAULT_AUTO_FIELD='django.db.models.AutoField',
+        INSTALLED_APPS=[
+            'django.contrib.contenttypes',
+            'django.contrib.auth',
+            'trusts',
+        ],
+        AUTHENTICATION_BACKENDS=['trusts.backends.TrustModelBackend'],
+        DATABASES={'default': {'ENGINE': 'django.db.backends.sqlite3', 'NAME': ':memory:'}},
+    )
+
+    import django
+    django.setup()
+
+    import trusts
+    from trusts.models import Trust
+    from trusts.backends import TrustModelBackend
+
+    trusts_file = Path(trusts.__file__).resolve()
+    if checkout == trusts_file or checkout in trusts_file.parents:
+        raise SystemExit('Imported trusts from the checkout: %s' % trusts_file)
+    if 'site-packages' not in str(trusts_file) and 'dist-packages' not in str(trusts_file):
+        raise SystemExit('trusts.__file__ is not a site-packages install: %s' % trusts_file)
+
+    print('wheel import ok')
+    print('django', django.get_version())
+    print('trusts.__file__', trusts_file)
+    print('Trust', Trust)
+    print('TrustModelBackend', TrustModelBackend)
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,6 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
+"""Thin setuptools wrapper. Authoritative metadata lives in pyproject.toml."""
 
-from __future__ import unicode_literals
+from setuptools import setup
 
-import os
-from setuptools import setup, find_packages
-
-
-README = open(os.path.join(os.path.dirname(__file__), 'README.md')).read()
-REQUIREMENTS = open(os.path.join(os.path.dirname(__file__), 'requirements.txt')).read()
-
-# allow setup.py to be run from any path
-os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
-
-setup(
-    name='django-trusts',
-    version='1.0.0.dev0',
-    description='Django authorization add-on for multiple organizations and object-level permission settings',
-    author='Thomas Yip',
-    author_email='thomasleaf@gmail.com',
-    long_description=README,
-    url='http://github.com/beedesk/django-trusts',
-    packages=find_packages(exclude=[]),
-    test_suite="tests.runtests.runtests",
-    include_package_data=True,
-    zip_safe=False,
-    install_requires=REQUIREMENTS,
-    license='BSD 2-Clause',
-    classifiers=[
-	'Development Status :: 4 - Beta',
-	'Framework :: Django :: 1.8',
-	'Intended Audience :: Developers',
-	'Intended Audience :: Information Technology',
-	'Intended Audience :: System Administrators',
-	'License :: OSI Approved :: BSD License',
-	'Natural Language :: English',
-	'Operating System :: OS Independent',
-	'Programming Language :: Python',
-	'Programming Language :: Python :: 2',
-	'Topic :: Software Development :: Libraries',
-    ],
-)
+setup()

--- a/tests/apps.py
+++ b/tests/apps.py
@@ -1,0 +1,7 @@
+from django.apps import AppConfig
+
+
+class TestsConfig(AppConfig):
+    name = 'tests'
+    label = 'trusts_tests'
+    default_auto_field = 'django.db.models.AutoField'

--- a/tests/migrations/0001_test_models.py
+++ b/tests/migrations/0001_test_models.py
@@ -1,0 +1,46 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import trusts.models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        ('auth', '0006_require_contenttypes_0002'),
+        ('trusts', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Category',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=40)),
+                ('trust', models.ForeignKey(default=1, on_delete=django.db.models.deletion.CASCADE, related_name='trusts_tests_category_content', to='trusts.trust')),
+            ],
+            options={
+                'default_permissions': ('add', 'read', 'change', 'delete'),
+                'permissions': (('add_topic_to_category', 'Add topic to a category'),),
+            },
+            bases=(trusts.models.ReadonlyFieldsMixin, models.Model),
+        ),
+        migrations.CreateModel(
+            name='TestGroupJunction',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=40)),
+                ('content', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='auth.group', unique=True)),
+                ('trust', models.ForeignKey(default=1, on_delete=django.db.models.deletion.CASCADE, related_name='trusts_tests_testgroupjunction', to='trusts.trust')),
+            ],
+            options={
+                'default_permissions': (),
+            },
+            bases=(trusts.models.ReadonlyFieldsMixin, models.Model),
+        ),
+        migrations.AlterUniqueTogether(
+            name='testgroupjunction',
+            unique_together={('content',)},
+        ),
+    ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,31 @@
+from django.db import models
+from django.contrib.auth.models import Group
+
+from trusts.models import Content, Junction
+
+
+class Category(Content):
+    name = models.CharField(max_length=40, null=False, blank=False)
+
+    class Meta:
+        default_permissions = ('add', 'read', 'change', 'delete')
+        permissions = (
+            ('add_topic_to_category', 'Add topic to a category'),
+        )
+        roles = (
+            ('public', ('read_category', 'add_topic_to_category')),
+            ('admin', ('read_category', 'add_category', 'change_category', 'add_topic_to_category')),
+            ('write', ('read_category', 'change_category', 'add_topic_to_category')),
+        )
+
+
+class TestGroupJunction(Junction):
+    content = models.ForeignKey(Group, unique=True, null=False, blank=False, on_delete=models.CASCADE)
+    name = models.CharField(max_length=40, null=False, blank=False)
+
+    class Meta:
+        content_roles = (
+            ('public', ('read_group', 'add_topic_to_group')),
+            ('admin', ('read_group', 'add_group', 'change_group', 'add_topic_to_group')),
+            ('write', ('read_group', 'change_group', 'add_topic_to_group')),
+        )

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -1,20 +1,23 @@
-# see https://docs.djangoproject.com/en/1.9/topics/testing/advanced/#using-the-django-test-runner-to-test-reusable-applications
-import os, sys
+# see https://docs.djangoproject.com/en/stable/topics/testing/advanced/#using-the-django-test-runner-to-test-reusable-applications
+import os
+import sys
+
 os.environ['DJANGO_SETTINGS_MODULE'] = 'tests.settings'
-test_dir = os.path.join(os.path.dirname(__file__), 'trusts')
-sys.path.insert(0, test_dir)
+root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, root)
 
 import django
 from django.test.utils import get_runner
 from django.conf import settings
 
+
 def runtests():
+    django.setup()
     TestRunner = get_runner(settings)
-    test_runner = TestRunner(verbosity=1, interactive=True)
-    if hasattr(django, 'setup'):
-        django.setup()
+    test_runner = TestRunner(verbosity=1, interactive=False)
     failures = test_runner.run_tests(['trusts'])
     sys.exit(bool(failures))
+
 
 if __name__ == '__main__':
     runtests()

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,13 @@
 SECRET_KEY = '01)%8q7ub=+yw7^#dz5s!6kkff6%al5f)_ayvep9_b&w1q-dvs'
 
+USE_TZ = True
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+LOGIN_URL = '/accounts/login/'
+STATIC_URL = '/static/'
+ALLOWED_HOSTS = ['beedesk.com', 'testserver', 'localhost']
+# Junction docs still describe content = ForeignKey(..., unique=True).
+SILENCED_SYSTEM_CHECKS = ['fields.W342']
+
 INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',
@@ -8,11 +16,33 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'trusts',
+    'tests.apps.TestsConfig',
 )
 
 AUTHENTICATION_BACKENDS = (
     'trusts.backends.TrustModelBackend',
 )
+
+MIDDLEWARE = (
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+)
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/trusts/__init__.py
+++ b/trusts/__init__.py
@@ -1,9 +1,6 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.apps import apps as django_apps
+from django.core.exceptions import ImproperlyConfigured
 
 
 ENTITY_MODEL_NAME = getattr(settings, 'TRUSTS_ENTITY_MODEL',
@@ -15,9 +12,10 @@ PERMISSION_MODEL_NAME = getattr(settings, 'TRUSTS_PERMISSION_MODEL', 'auth.Permi
 
 DEFAULT_SETTLOR = getattr(settings, 'TRUSTS_DEFAULT_SETTLOR', None)
 
-ALLOW_NULL_SETTLOR = getattr(settings, 'TRUSTS_ALLOW_NULL_SETTLOR', DEFAULT_SETTLOR == None)
+ALLOW_NULL_SETTLOR = getattr(settings, 'TRUSTS_ALLOW_NULL_SETTLOR', DEFAULT_SETTLOR is None)
 
 ROOT_PK = getattr(settings, 'TRUSTS_ROOT_PK', 1)
+
 
 def get_entity_model():
     """
@@ -33,12 +31,13 @@ def get_entity_model():
             "TRUSTS_ENTITY_MODEL or AUTH_USER_MODEL refers to model '%s' that has not been installed" % ENTITY_MODEL_NAME
         )
 
+
 def get_group_model():
     """
     Returns the Group model
     """
     try:
-        return django_apps.get_model(GROUP_MODEL)
+        return django_apps.get_model(GROUP_MODEL_NAME)
     except ValueError:
         raise ImproperlyConfigured("TRUSTS_GROUP_MODEL must be of the form 'app_label.model_name'")
     except LookupError:
@@ -46,9 +45,10 @@ def get_group_model():
             "TRUSTS_GROUP_MODEL refers to model '%s' that has not been installed" % GROUP_MODEL_NAME
         )
 
+
 def get_permission_model():
     """
-    Returns the Group model
+    Returns the Permission model
     """
     try:
         return django_apps.get_model(PERMISSION_MODEL_NAME)
@@ -58,5 +58,3 @@ def get_permission_model():
         raise ImproperlyConfigured(
             "TRUSTS_PERMISSION_MODEL refers to model '%s' that has not been installed" % PERMISSION_MODEL_NAME
         )
-
-default_app_config = 'trusts.apps.AppConfig'

--- a/trusts/apps.py
+++ b/trusts/apps.py
@@ -1,7 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-
 from django.apps import AppConfig as DjangoAppConfig
 
 
@@ -9,3 +5,5 @@ class AppConfig(DjangoAppConfig):
     name = 'trusts'
     verbose_name = "Django Trusts Add-in"
     label = 'trusts'
+    # Preserve the historical AutoField primary keys from 0001_initial.
+    default_auto_field = 'django.db.models.AutoField'

--- a/trusts/backends.py
+++ b/trusts/backends.py
@@ -1,7 +1,4 @@
-from __future__ import unicode_literals
-
-from django.db.models import F, Q, QuerySet
-from django.contrib.auth import get_user_model
+from django.db.models import Q, QuerySet
 from django.contrib.auth.backends import ModelBackend
 
 from trusts.models import Trust, Content
@@ -45,7 +42,7 @@ class TrustModelBackendMixin(object):
         groups.
         """
 
-        if user_obj.is_anonymous() or obj is None:
+        if user_obj.is_anonymous or obj is None:
             return super(TrustModelBackendMixin, self).get_group_permissions(user_obj, obj)
 
         if Content.is_content(obj):
@@ -55,7 +52,7 @@ class TrustModelBackendMixin(object):
         return []
 
     def get_all_permissions(self, user_obj, obj=None):
-        if user_obj.is_anonymous() or obj is None:
+        if user_obj.is_anonymous or obj is None:
             return super(TrustModelBackendMixin, self).get_all_permissions(user_obj, obj)
 
         if not hasattr(user_obj, '_trust_perm_cache'):
@@ -87,7 +84,7 @@ class TrustModelBackendMixin(object):
     def permission_condition_met(self, func, user_obj, perm, obj):
         if isinstance(obj, QuerySet):
             objs = obj.all()
-        elif hasattr(trusts, '__iter__'):
+        elif hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes)):
             objs = obj
         else:
             objs = [obj]

--- a/trusts/decorators.py
+++ b/trusts/decorators.py
@@ -1,14 +1,14 @@
 from functools import wraps
+from urllib.parse import urlparse
+from operator import and_, or_
 
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
 from django.shortcuts import resolve_url
 from django.contrib.contenttypes.models import ContentType
-from django.utils.decorators import available_attrs
-from django.utils.six.moves.urllib.parse import urlparse
 from django.http import Http404
-from operator import and_, or_
 
 from trusts import utils
 
@@ -23,7 +23,7 @@ class P(object):
 
     def __and__(self, other):
         if not isinstance(other, self.__class__):
-            raise TypeError("unsupported operand type(s) for &: '%s' and '%s'" % type(self), type(other))
+            raise TypeError("unsupported operand type(s) for &: '%s' and '%s'" % (type(self), type(other)))
 
         p = type(self)('')
         p._left_operand = self
@@ -33,7 +33,7 @@ class P(object):
 
     def __or__(self, other):
         if not isinstance(other, self.__class__):
-            raise TypeError("unsupported operand type(s) for |: '%s' and '%s'" % type(self), type(other))
+            raise TypeError("unsupported operand type(s) for |: '%s' and '%s'" % (type(self), type(other)))
 
         p = type(self)('')
         p._left_operand = self
@@ -42,11 +42,11 @@ class P(object):
         return p
 
     def __repr__(self):
-        return self.__unicode__()
+        return self.__str__()
 
-    def __unicode__(self):
+    def __str__(self):
         if not self._operator:
-            return self.perm
+            return self._perm
 
         return 'P object'
 
@@ -101,7 +101,7 @@ def request_passes_test(test_func, login_url=None, redirect_field_name=REDIRECT_
     '''
 
     def decorator(view_func):
-        @wraps(view_func, assigned=available_attrs(view_func))
+        @wraps(view_func)
         def _wrapped_view(request, *args, **kwargs):
             if test_func(request, *args, **kwargs):
                 return view_func(request, *args, **kwargs)
@@ -115,7 +115,6 @@ def request_passes_test(test_func, login_url=None, redirect_field_name=REDIRECT_
             if ((not login_scheme or login_scheme == current_scheme) and
                     (not login_netloc or login_netloc == current_netloc)):
                 path = request.get_full_path()
-            from django.contrib.auth.views import redirect_to_login
             return redirect_to_login(
                 path, resolved_login_url, redirect_field_name)
         return _wrapped_view
@@ -128,7 +127,7 @@ def _collect_args(args, fieldlookups):
     if not fieldlookups:
         return results
 
-    for lookup, arg_name in fieldlookups.iteritems():
+    for lookup, arg_name in fieldlookups.items():
         if arg_name in args:
             results[lookup] = args[arg_name]
         else:
@@ -147,7 +146,7 @@ def _get_permissible_items(perm, request, fieldlookups):
 
         return ctype.model_class().objects.filter(**fieldlookups)
     except ObjectDoesNotExist:
-        raise ValueError('Permission code must be of the form "app_label.action_modelname". Actual: %s' % permext)
+        raise ValueError('Permission code must be of the form "app_label.action_modelname". Actual: %s' % perm)
 
 
 def _resolve_fieldlookups(request, kwargs, fieldlookups_kwargs=None, fieldlookups_getparams=None, fieldlookups_postparams=None, **fieldlookups):

--- a/trusts/management/commands/create_trust_root.py
+++ b/trusts/management/commands/create_trust_root.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-
 from django.core.management.base import BaseCommand
 from django.conf import settings
 
+
 def create_root_trust(Trust, pk, settlor, title):
+    if Trust.objects.filter(pk=pk).exists():
+        return Trust.objects.get(pk=pk)
+
     kwargs = {'id': pk, 'title': title}
     if settlor is not None:
         kwargs.update({'settlor_id': settlor})
@@ -13,6 +13,7 @@ def create_root_trust(Trust, pk, settlor, title):
     trust = Trust(**kwargs)
     trust.trust = trust
     trust.save()
+    return trust
 
 
 class Command(BaseCommand):
@@ -25,9 +26,5 @@ class Command(BaseCommand):
         settlor = getattr(settings, 'TRUSTS_ROOT_SETTLOR', None)
         title = getattr(settings, 'TRUSTS_ROOT_TITLE', 'In Trust We Trust')
 
-        if 'apps' in options:
-            apps = options['apps']
-            Trust = apps.get_model('trusts', 'trust')
-        else:
-            from trusts.models import Trust
+        from trusts.models import Trust
         create_root_trust(Trust, pk, settlor, title)

--- a/trusts/management/commands/update_roles_permissions.py
+++ b/trusts/management/commands/update_roles_permissions.py
@@ -1,18 +1,7 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import unicode_literals
-
-
-import getpass
-import unicodedata
-
-from django.conf import settings
-from django.core import exceptions
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.db import DEFAULT_DB_ALIAS, router
 from django.db.models import Q
-from django.utils.encoding import DEFAULT_LOCALE_ENCODING
-from django.utils import six
+
 
 def _process_roles(Permission, model_roles, content_klass, roles, using):
     for rolename, perm_names in roles:
@@ -27,6 +16,7 @@ def _process_roles(Permission, model_roles, content_klass, roles, using):
         model_roles[rolename].update([Permission.objects.get(content_type=ctype, codename=perm_name)
                 for perm_name in perm_names
         ])
+
 
 def update_roles_permissions(Role, Permission, RolePermission, app_config, verbosity=2, interactive=True, using=DEFAULT_DB_ALIAS, **kwargs):
     if not router.allow_migrate_model(using, Role):

--- a/trusts/migrations/0001_initial.py
+++ b/trusts/migrations/0001_initial.py
@@ -1,17 +1,18 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from django.db import migrations, models
 from django.conf import settings
-from django.core.management import call_command
 
 from trusts import ENTITY_MODEL_NAME, GROUP_MODEL_NAME, PERMISSION_MODEL_NAME, DEFAULT_SETTLOR, ALLOW_NULL_SETTLOR, ROOT_PK
+from trusts.management.commands.create_trust_root import create_root_trust
 import trusts.models
 
 
 def forward(apps, schema_editor):
     if getattr(settings, 'TRUSTS_CREATE_ROOT', True):
-        call_command('create_trust_root', apps=apps)
+        Trust = apps.get_model('trusts', 'trust')
+        pk = getattr(settings, 'TRUSTS_ROOT_PK', 1)
+        settlor = getattr(settings, 'TRUSTS_ROOT_SETTLOR', None)
+        title = getattr(settings, 'TRUSTS_ROOT_TITLE', 'In Trust We Trust')
+        create_root_trust(Trust, pk, settlor, title)
 
 def backward(apps, schema_editor):
     pass
@@ -29,8 +30,8 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', auto_created=True, primary_key=True, serialize=False)),
                 ('title', models.CharField(verbose_name='title', max_length=40)),
-                ('settlor', models.ForeignKey(to=ENTITY_MODEL_NAME, default=DEFAULT_SETTLOR, null=ALLOW_NULL_SETTLOR)),
-                ('trust', models.ForeignKey(to='trusts.Trust', related_name='trusts_trust_content', default=ROOT_PK)),
+                ('settlor', models.ForeignKey(to=ENTITY_MODEL_NAME, default=DEFAULT_SETTLOR, null=ALLOW_NULL_SETTLOR, on_delete=models.CASCADE)),
+                ('trust', models.ForeignKey(to='trusts.Trust', related_name='trusts_trust_content', default=ROOT_PK, on_delete=models.CASCADE)),
                 ('groups', models.ManyToManyField(to=GROUP_MODEL_NAME, related_name='trusts', verbose_name='groups', help_text='The groups this trust grants permissions to. A user willget all permissions granted to each of his/her group.')),
             ],
             options={
@@ -42,9 +43,9 @@ class Migration(migrations.Migration):
             name='TrustUserPermission',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, verbose_name='ID', serialize=False)),
-                ('entity', models.ForeignKey(to=ENTITY_MODEL_NAME, related_name='trustpermissions')),
-                ('permission', models.ForeignKey(to=PERMISSION_MODEL_NAME, related_name='trustentities')),
-                ('trust', models.ForeignKey(to='trusts.Trust', related_name='trustees')),
+                ('entity', models.ForeignKey(to=ENTITY_MODEL_NAME, related_name='trustpermissions', on_delete=models.CASCADE)),
+                ('permission', models.ForeignKey(to=PERMISSION_MODEL_NAME, related_name='trustentities', on_delete=models.CASCADE)),
+                ('trust', models.ForeignKey(to='trusts.Trust', related_name='trustees', on_delete=models.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -52,7 +53,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', primary_key=True, serialize=False, auto_created=True)),
                 ('managed', models.BooleanField(default=False)),
-                ('permission', models.ForeignKey(to='auth.Permission', related_name='rolepermissions')),
+                ('permission', models.ForeignKey(to='auth.Permission', related_name='rolepermissions', on_delete=models.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -67,7 +68,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='rolepermission',
             name='role',
-            field=models.ForeignKey(to='trusts.Role', related_name='rolepermissions'),
+            field=models.ForeignKey(to='trusts.Role', related_name='rolepermissions', on_delete=models.CASCADE),
         ),
         migrations.AlterUniqueTogether(
             name='trust',

--- a/trusts/migrations/0001_initial.py
+++ b/trusts/migrations/0001_initial.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', auto_created=True, primary_key=True, serialize=False)),
                 ('title', models.CharField(verbose_name='title', max_length=40)),
                 ('settlor', models.ForeignKey(to=ENTITY_MODEL_NAME, default=DEFAULT_SETTLOR, null=ALLOW_NULL_SETTLOR, on_delete=models.CASCADE)),
-                ('trust', models.ForeignKey(to='trusts.Trust', related_name='trusts_trust_content', default=ROOT_PK, on_delete=models.CASCADE)),
+                ('trust', models.ForeignKey(to='trusts.Trust', related_name='%(app_label)s_%(class)s_content', default=ROOT_PK, on_delete=models.CASCADE)),
                 ('groups', models.ManyToManyField(to=GROUP_MODEL_NAME, related_name='trusts', verbose_name='groups', help_text='The groups this trust grants permissions to. A user willget all permissions granted to each of his/her group.')),
             ],
             options={

--- a/trusts/models.py
+++ b/trusts/models.py
@@ -1,14 +1,7 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-from datetime import datetime
-
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import signals, Q, options
-from django.contrib.contenttypes.models import ContentType
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from trusts import ENTITY_MODEL_NAME, PERMISSION_MODEL_NAME, GROUP_MODEL_NAME, \
                     DEFAULT_SETTLOR, ALLOW_NULL_SETTLOR, ROOT_PK, utils
@@ -18,13 +11,14 @@ options.DEFAULT_NAMES += ('roles', 'permission_conditions',
                           'content_roles', 'content_permission_conditions'
     )
 
+
 class TrustManager(models.Manager):
     def get_or_create_settlor_default(self, settlor, defaults={}, **kwargs):
         if 'trust' in kwargs:
             raise TypeError('"%s" are invalid keyword arguments' % 'trust')
         if settlor is None:
             raise ValueError('"settlor" must has a value.')
-        if settlor.is_anonymous():
+        if settlor.is_anonymous:
             # @TODO -- Handle anonymous settings
             raise ValueError('Anonymous is not yet supported.')
 
@@ -71,14 +65,24 @@ class TrustManager(models.Manager):
 
 
 class ReadonlyFieldsMixin(object):
+    def _readonly_attname(self, field_name):
+        try:
+            return self._meta.get_field(field_name).attname
+        except Exception:
+            return field_name
+
     def __init__(self, *args, **kwargs):
         super(ReadonlyFieldsMixin, self).__init__(*args, **kwargs)
 
         if hasattr(self, '_readonly_fields'):
-            self._state.init_fields = {
-                field: getattr(self, field) for field in self._readonly_fields
-                        if hasattr(self, field)
-            }
+            # Snapshot column values from __dict__. getattr() on a ForeignKey
+            # in Django 6.1 fetch-mode would load the related object and recurse
+            # on Trust.trust (the self-referential root).
+            self._state.init_fields = {}
+            for field in self._readonly_fields:
+                attname = self._readonly_attname(field)
+                if attname in self.__dict__:
+                    self._state.init_fields[field] = self.__dict__[attname]
 
     def clean(self):
         super(ReadonlyFieldsMixin, self).clean()
@@ -87,13 +91,14 @@ class ReadonlyFieldsMixin(object):
             for field in self._readonly_fields:
                 if field in self._state.init_fields:
                     saved_value = self._state.init_fields[field]
-                    if saved_value != getattr(self, field):
+                    attname = self._readonly_attname(field)
+                    if saved_value != self.__dict__.get(attname, getattr(self, attname)):
                         raise ValidationError('Field "%s" is readonly.' % 'trust')
 
 
 class Content(ReadonlyFieldsMixin, models.Model):
     trust = models.ForeignKey('trusts.Trust', related_name='%(app_label)s_%(class)s_content',
-                default=ROOT_PK, null=False, blank=False)
+                default=ROOT_PK, null=False, blank=False, on_delete=models.CASCADE)
     _contents = {}
     _conditions = {}
 
@@ -111,11 +116,11 @@ class Content(ReadonlyFieldsMixin, models.Model):
 
     @staticmethod
     def register_content(klass, fieldlookup=None):
+        short_name = utils.get_short_model_name(klass)
         if fieldlookup is None:
-            content_model_fields = [f for f in klass._meta.fields if f.rel is not None and f.name == 'trust']
+            content_model_fields = [f for f in klass._meta.fields if f.remote_field is not None and f.name == 'trust']
             if len(content_model_fields) != 1:
                 raise AttributeError('Expect "trust" field in model %s.' % short_name)
-        short_name = utils.get_short_model_name(klass)
         Content._contents[short_name] = fieldlookup
 
         if hasattr(klass._meta, 'permission_conditions'):
@@ -157,7 +162,8 @@ class Content(ReadonlyFieldsMixin, models.Model):
 
 class Trust(Content):
     title = models.CharField(max_length=40, null=False, blank=False, verbose_name=_('title'))
-    settlor = models.ForeignKey(ENTITY_MODEL_NAME, default=DEFAULT_SETTLOR, null=ALLOW_NULL_SETTLOR, blank=False)
+    settlor = models.ForeignKey(ENTITY_MODEL_NAME, default=DEFAULT_SETTLOR, null=ALLOW_NULL_SETTLOR, blank=False,
+                on_delete=models.CASCADE)
     groups = models.ManyToManyField(GROUP_MODEL_NAME, related_name='trusts',
                 verbose_name=_('groups'),
                 help_text=_('The groups this trust grants permissions to. A user will'
@@ -181,21 +187,24 @@ Content.register_content(Trust)
 class Role(models.Model):
     name = models.CharField(max_length=80, null=False, blank=False, unique=True,
                 help_text=_('The name of the role. Corresponds to the key of model\'s trusts option.'))
-    groups = models.ManyToManyField(GROUP_MODEL_NAME, related_name='roles', null=False, blank=False,
+    groups = models.ManyToManyField(GROUP_MODEL_NAME, related_name='roles', blank=False,
                 verbose_name=_('groups')
             )
     permissions = models.ManyToManyField(PERMISSION_MODEL_NAME,
                 through='trusts.RolePermission',
-                related_name='roles', null=False, blank=False,
+                related_name='roles', blank=False,
                 verbose_name=_('permissions')
             )
 
     class Meta:
         pass
 
+
 class RolePermission(models.Model):
-    role = models.ForeignKey('trusts.Role', related_name='rolepermissions', null=False, blank=False)
-    permission = models.ForeignKey(PERMISSION_MODEL_NAME, related_name='rolepermissions', null=False, blank=False)
+    role = models.ForeignKey('trusts.Role', related_name='rolepermissions', null=False, blank=False,
+                on_delete=models.CASCADE)
+    permission = models.ForeignKey(PERMISSION_MODEL_NAME, related_name='rolepermissions', null=False, blank=False,
+                on_delete=models.CASCADE)
     managed = models.BooleanField(null=False, blank=False, default=False)
 
     class Meta:
@@ -203,9 +212,12 @@ class RolePermission(models.Model):
 
 
 class TrustUserPermission(models.Model):
-    trust = models.ForeignKey('trusts.Trust', related_name='trustees', null=False, blank=False)
-    entity = models.ForeignKey(ENTITY_MODEL_NAME, related_name='trustpermissions', null=False, blank=False)
-    permission = models.ForeignKey(PERMISSION_MODEL_NAME, related_name='trustentities', null=False, blank=False)
+    trust = models.ForeignKey('trusts.Trust', related_name='trustees', null=False, blank=False,
+                on_delete=models.CASCADE)
+    entity = models.ForeignKey(ENTITY_MODEL_NAME, related_name='trustpermissions', null=False, blank=False,
+                on_delete=models.CASCADE)
+    permission = models.ForeignKey(PERMISSION_MODEL_NAME, related_name='trustentities', null=False, blank=False,
+                on_delete=models.CASCADE)
 
     class Meta:
         unique_together = ('trust', 'entity', 'permission')
@@ -213,7 +225,7 @@ class TrustUserPermission(models.Model):
 
 class Junction(ReadonlyFieldsMixin, models.Model):
     trust = models.ForeignKey('trusts.Trust', related_name='%(app_label)s_%(class)s',
-                default=ROOT_PK, null=False, blank=False)
+                default=ROOT_PK, null=False, blank=False, on_delete=models.CASCADE)
     _readonly_fields = ('trust',)
 
     class Meta:
@@ -232,9 +244,9 @@ class Junction(ReadonlyFieldsMixin, models.Model):
     @classmethod
     def get_content_model(cls):
         # introspect for the content model class with the easy case
-        content_model_fields = [f for f in cls._meta.fields if f.rel is not None and f.name != 'trust']
+        content_model_fields = [f for f in cls._meta.fields if f.remote_field is not None and f.name != 'trust']
         if len(content_model_fields) == 1:
-            return content_model_fields[0].rel.to
+            return content_model_fields[0].remote_field.model
         raise NotImplementedError('Juctnion\'s classmethod "get_content_model" is not implemented.')
 
     @classmethod

--- a/trusts/tests.py
+++ b/trusts/tests.py
@@ -3,10 +3,9 @@ import json
 import unittest
 
 from decimal import Decimal
-from urllib import urlencode
-from urlparse import urlparse
+from urllib.parse import urlencode, urlparse
 from datetime import date, datetime, timedelta
-from mock import Mock
+from unittest.mock import Mock
 
 from django.apps import apps
 from django.db import models, connection, IntegrityError
@@ -15,12 +14,11 @@ from django.db.models.base import ModelBase
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
-from django.core.management.color import no_style
 from django.contrib.auth.models import User, Group, Permission
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.management import create_permissions
 from django.contrib.contenttypes.models import ContentType
-from django.contrib.contenttypes.management import update_contenttypes
+from django.contrib.contenttypes.management import create_contenttypes
 from django.test import TestCase, TransactionTestCase
 from django.test.client import MULTIPART_CONTENT, Client
 from django.http.request import HttpRequest
@@ -29,6 +27,7 @@ from trusts.models import Trust, TrustManager, Content, Junction, \
                           Role, RolePermission, TrustUserPermission
 from trusts.backends import TrustModelBackend
 from trusts.decorators import permission_required, P, K, G, O
+from tests.models import Category, TestGroupJunction
 
 
 def create_test_users(test):
@@ -159,6 +158,26 @@ class TrustTest(TestCase):
         except ValidationError as ve:
             pass
 
+    def test_own_condition_requires_settlor(self):
+        """The :own condition is settlor-only and does not leak across users."""
+        trust = Trust(settlor=self.user, trust=Trust.objects.get_root(), title='Owned Trust')
+        trust.save()
+        change = Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Trust),
+            codename='change_trust',
+        )
+        TrustUserPermission(trust=trust, entity=self.user, permission=change).save()
+        TrustUserPermission(trust=trust, entity=self.user1, permission=change).save()
+
+        reload_test_users(self)
+        child = Trust(settlor=self.user, title='Child of owned', trust=trust)
+        child.save()
+        # Permissions resolve via the parent trust; :own is evaluated on the object.
+        self.assertTrue(self.user.has_perm('trusts.change_trust', child))
+        self.assertTrue(self.user.has_perm('trusts.change_trust:own', child))
+        self.assertTrue(self.user1.has_perm('trusts.change_trust', child))
+        self.assertFalse(self.user1.has_perm('trusts.change_trust:own', child))
+
 class DecoratorsTest(TestCase):
     def setUp(self):
         super(DecoratorsTest, self).setUp()
@@ -265,48 +284,6 @@ class DecoratorsTest(TestCase):
         self.assertEqual(obj.first().pk, self.group.pk)
 
 
-class RuntimeModel(object):
-    """
-    Base class for tests of runtime model mixins.
-    """
-
-    def setUp(self):
-        # Create the schema for our test model
-        self._style = no_style()
-        sql, _ = connection.creation.sql_create_model(self.model, self._style)
-
-        with connection.cursor() as c:
-            for statement in sql:
-                c.execute(statement)
-
-        content_model = self.content_model if hasattr(self, 'content_model') else self.model
-        app_config = apps.get_app_config(content_model._meta.app_label)
-        update_contenttypes(app_config, verbosity=1, interactive=False)
-        create_permissions(app_config, verbosity=1, interactive=False)
-
-        super(RuntimeModel, self).setUp()
-
-    def workaround_contenttype_cache_bug(self):
-        # workaround bug: https://code.djangoproject.com/ticket/10827
-        from django.contrib.contenttypes.models import ContentType
-        ContentType.objects.clear_cache()
-
-    def tearDown(self):
-        # Delete the schema for the test model
-        content_model = self.content_model if hasattr(self, 'content_model') else self.model
-        sql = connection.creation.sql_destroy_model(self.model, (), self._style)
-
-        with connection.cursor() as c:
-            for statement in sql:
-                c.execute(statement)
-
-        self.workaround_contenttype_cache_bug()
-
-        super(RuntimeModel, self).tearDown()
-
-        apps.get_app_config('trusts').models.pop(self.model._meta.model_name.lower())
-
-
 class ContentModel(object):
     def create_test_fixtures(self):
         self.group = Group(name="Test Group")
@@ -338,38 +315,28 @@ class ContentModel(object):
         self.app_label = content_model._meta.app_label
         self.model_name = content_model._meta.model_name
 
+        # Junction content_roles reference extra Group permissions.
+        group_ct = ContentType.objects.get_for_model(Group)
+        Permission.objects.get_or_create(codename='read_group', content_type=group_ct)
+        Permission.objects.get_or_create(codename='add_topic_to_group', content_type=group_ct)
+
         self.set_perms()
 
 
-class ContentModelMixin(RuntimeModel, ContentModel):
-    class CategoryMixin(Content):
-        name = models.CharField(max_length=40, null=False, blank=False)
-
-        class Meta:
-            abstract = True
-            default_permissions = ('add', 'read', 'change', 'delete')
-            permissions = (
-                ('add_topic_to_category', 'Add topic to a category'),
-            )
-            roles = (
-                ('public', ('read_category', 'add_topic_to_category')),
-                ('admin', ('read_category', 'add_category', 'change_category', 'add_topic_to_category')),
-                ('write', ('read_category', 'change_category', 'add_topic_to_category')),
-            )
-
+class ContentModelMixin(ContentModel):
     def setUp(self):
-        mixin = self.CategoryMixin
-
-        # Create a dummy model which extends the mixin
-        self.model = ModelBase('Category', (mixin, models.Model),
-            {'__module__': mixin.__module__})
-
+        self.model = Category
+        self._original_roles = tuple(Category._meta.roles)
         super(ContentModelMixin, self).setUp()
 
-    def create_content(self, trust):
-        content = self.model(trust=trust)
-        content.save()
+    def tearDown(self):
+        Category._meta.roles = self._original_roles
+        super(ContentModelMixin, self).tearDown()
 
+    def create_content(self, trust):
+        import uuid
+        content = self.model(trust=trust, name='category-%s' % uuid.uuid4())
+        content.save()
         return content
 
     def append_model_roles(self, rolename, perms):
@@ -382,31 +349,21 @@ class ContentModelMixin(RuntimeModel, ContentModel):
         return self.model._meta.roles
 
 
-class JunctionModelMixin(RuntimeModel, ContentModel):
-    class GroupJunctionMixin(Junction):
-        content = models.ForeignKey(Group, unique=True, null=False, blank=False)
-        name = models.CharField(max_length=40, null=False, blank=False)
-
-        class Meta:
-            abstract = True
-            content_roles = (
-                ('public', ('read_group', 'add_topic_to_group')),
-                ('admin', ('read_group', 'add_group', 'change_group', 'add_topic_to_group')),
-                ('write', ('read_group', 'change_group', 'add_topic_to_group')),
-            )
-
+class JunctionModelMixin(ContentModel):
     def setUp(self):
-        mixin = self.GroupJunctionMixin
-        self.model = ModelBase('TestGroupJunction', (mixin, models.Model),
-            {'__module__': mixin.__module__})
-
+        self.model = TestGroupJunction
         self.content_model = Group
+        self._original_roles = tuple(TestGroupJunction._meta.content_roles)
 
         ctype = ContentType.objects.get_for_model(Group)
         Permission.objects.get_or_create(codename='read_group', content_type=ctype)
         Permission.objects.get_or_create(codename='add_topic_to_group', content_type=ctype)
 
         super(JunctionModelMixin, self).setUp()
+
+    def tearDown(self):
+        TestGroupJunction._meta.content_roles = self._original_roles
+        super(JunctionModelMixin, self).tearDown()
 
     def append_model_roles(self, rolename, perms):
         self.model._meta.content_roles += ((rolename, perms, ), )
@@ -423,7 +380,7 @@ class JunctionModelMixin(RuntimeModel, ContentModel):
         content = self.content_model(name=str(uuid.uuid4()))
         content.save()
 
-        junction = self.model(content=content, trust=trust)
+        junction = self.model(content=content, trust=trust, name='junction-%s' % content.pk)
         junction.save()
 
         return content
@@ -588,6 +545,47 @@ class TrustContentTestMixin(ContentModel):
 
         self.assertFalse(had)
 
+    def test_organization_isolation_denies_cross_trust_access(self):
+        """Users authorized in one organization must be denied in another.
+
+        A trust is the organization boundary. Granting change on Org A must
+        not grant change on Org B, including mixed QuerySet checks.
+        """
+        org_a = Trust(settlor=self.user, trust=Trust.objects.get_root(), title='Org A')
+        org_a.save()
+        org_b = Trust(settlor=self.user1, trust=Trust.objects.get_root(), title='Org B')
+        org_b.save()
+
+        content_a = self.create_content(org_a)
+        content_b = self.create_content(org_b)
+
+        TrustUserPermission(trust=org_a, entity=self.user, permission=self.perm_change).save()
+        TrustUserPermission(trust=org_b, entity=self.user1, permission=self.perm_change).save()
+
+        reload_test_users(self)
+
+        self.assertTrue(self.user.has_perm(self.get_perm_code(self.perm_change), content_a))
+        self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_change), content_b))
+        self.assertTrue(self.user1.has_perm(self.get_perm_code(self.perm_change), content_b))
+        self.assertFalse(self.user1.has_perm(self.get_perm_code(self.perm_change), content_a))
+
+        content_model = self.content_model if hasattr(self, 'content_model') else self.model
+        mixed = content_model.objects.filter(pk__in=[content_a.pk, content_b.pk])
+        self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_change), mixed))
+        self.assertFalse(self.user1.has_perm(self.get_perm_code(self.perm_change), mixed))
+
+    def test_denied_access_without_grant(self):
+        """A user with no trustee/group grant is denied on organization content."""
+        org = Trust(settlor=self.user, trust=Trust.objects.get_root(), title='Denied Org')
+        org.save()
+        content = self.create_content(org)
+
+        reload_test_users(self)
+        self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_change), content))
+        self.assertFalse(self.user1.has_perm(self.get_perm_code(self.perm_change), content))
+        self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_add), content))
+        self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_delete), content))
+
     def test_read_permissions_added(self):
         ct = ContentType.objects.get_for_model(self.model)
         self.assertIsNotNone(Permission.objects.get(
@@ -613,11 +611,11 @@ class RoleTestMixin(object):
         rp.save()
 
         try:
-            rp = RolePermission(role=role, permission=self.perm_change)
+            rp = RolePermission(role=self.role, permission=self.perm_change)
             rp.save()
 
-            fail('Duplicate is not detected')
-        except:
+            self.fail('Duplicate is not detected')
+        except IntegrityError:
             pass
 
     def test_has_perm(self):
@@ -811,7 +809,7 @@ class RoleTestMixin(object):
 class TrustJunctionTestCase(TrustContentTestMixin, JunctionModelMixin, TransactionTestCase):
     @unittest.expectedFailure
     def test_read_permissions_added(self):
-        super(JunctionTestCase, self).test_read_permissions_added()
+        super(TrustJunctionTestCase, self).test_read_permissions_added()
 
 
 class TrustContentTestCase(TrustContentTestMixin, ContentModelMixin, TransactionTestCase):

--- a/trusts/utils.py
+++ b/trusts/utils.py
@@ -1,22 +1,21 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-import six
 from django.db.models import Model
 
+
 def get_short_model_name_lower(klass):
-    if isinstance(klass, six.string_types):
+    if isinstance(klass, str):
         return klass.lower()
     if issubclass(klass, Model):
         return '%s.%s' % (klass._meta.app_label.lower(), klass._meta.model_name)
     return ''
 
+
 def get_short_model_name(klass):
-    if isinstance(klass, six.string_types):
+    if isinstance(klass, str):
         return klass
     if issubclass(klass, Model):
         return '%s.%s' % (klass._meta.app_label, klass._meta.object_name)
     return ''
+
 
 def parse_perm_code(perm):
     applabel, action_modelname_permcode = perm.split('.', 1)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #14. Also implements the coordinated #15 pieces required for a testable gate (latest stable Django + real CI), including the review-requested legacy-upgrade executable check.

A Python-only intermediate against Django 1.8 cannot be installed or tested on current CPython, so this is one PR with separately explained sections. This is **not** a published or supported 1.0 release, not a PyPI upload, and not a permission-model redesign.

@chatforthomas — ready for re-review of `8a3236f` (addresses CHANGES_REQUESTED on `d5361ce`).

## migrates.md stance

**This PR does include API/compatibility method records in `migrates.md`.** Public authorization call sites (`has_perm` / `has_perms`, `permission_required`, `P`/`K`/`G`/`O`, `Trust` manager methods, `Content`/`Junction` subclassing) keep their signatures and intended allow/deny behavior. Recorded changes are the Django/Python compatibility requirements and two small command/internal fixes:

- Every Trusts `ForeignKey` now declares `on_delete=models.CASCADE` (Django 1.8 implicit default).
- `P.__unicode__` removed; `str(p)` / `P.__str__` is the Python 3 display method.
- `user.is_anonymous` property (Django ≥1.10) used internally.
- `create_trust_root` is idempotent; `call_command(..., apps=apps)` is gone because Django 6.1 rejects unknown command options. `0001_initial` calls `create_root_trust` with the historical model.
- Internal Django 1.8 / Python 2 shims removed (`ugettext_lazy`, `field.rel`, `iteritems`, `six`, `available_attrs`, `default_app_config`).
- `ReadonlyFieldsMixin` snapshots FK column values so Django 6.1 fetch modes do not recurse on the self-referential root trust. Readonly rules are unchanged.

Authorization implications are called out in `migrates.md` with a migration-bot checklist. No permission-model redesign.

## Supported matrix (checked 2026-09-07)

| Component | Declared | Sources |
| --- | --- | --- |
| Latest stable Django | **6.1.1**, require `Django>=6.1,<6.2` | https://www.djangoproject.com/download/ |
| Django 6.1 Python | **3.12, 3.13, 3.14** | https://docs.djangoproject.com/en/stable/faq/install/ and 6.1 release notes |
| CPython support | 3.14/3.13 bugfix; 3.12 security; 3.15 prerelease | https://devguide.python.org/versions/ |

Details: [docs/support-matrix.md](docs/support-matrix.md).

CI: authorization tests, fresh migrate, and `scripts/verify-legacy-upgrade.py` on each declared Python version. The `package` job runs on **Python 3.12 only** (representative install of the declared range).

## Review follow-up (`8a3236f`)

1. **Wheel import is isolated.** `scripts/verify-wheel-install.py` is run from a temporary directory with `PYTHONPATH` cleared. It refuses checkout-as-cwd, rejects the checkout root on `sys.path`, and requires `trusts.__file__` to be under `site-packages` / `dist-packages`.
2. **Legacy upgrade is executable.** `scripts/verify-legacy-upgrade.py` builds a representative 0.10.3-shaped SQLite DB: contrib migrations only, historical `0001` DDL from `scripts/legacy/trusts_0001_sqlite.sql`, `trusts.0001_initial` already recorded, then modern `migrate` without faking or reapplying Trusts 0001. It asserts the Trusts plan stays empty and checks the root row plus allow/deny/isolation. This is not a captured production dump and not a full Django 1.8 contrib-schema upgrade; those limits are documented. `#15` is therefore implemented for the Trusts-specific already-applied-0001 path.
3. **Support-matrix wording** now matches the 3.12-only package job.

## #14 — Python 3 and packaging

- Inspected the preserved implementation: `unicode_literals`, `six`/`django.utils.six`, `iteritems`, `__unicode__`, `urllib`/`urlparse`, standalone `mock`/`funcsigs`/`pbr`.
- `pyproject.toml` is authoritative (`requires-python >=3.12`, Django 6.1 classifiers). `setup.py` is a thin wrapper.
- Removed Python 2 classifiers and `six`, `funcsigs`, `mock`, `pbr`, `docutils` install dependencies.
- Built sdist + wheel (`django_trusts-1.0.0.dev0`); `twine check` passed; isolated wheel import of `Trust` and `TrustModelBackend` succeeded.

## #15 — Django 6.1 and real CI

Django API inventory applied in this PR:

- `ForeignKey.on_delete` (required)
- `ugettext_lazy` → `gettext_lazy`
- `field.rel` → `field.remote_field`
- `user.is_anonymous()` → property
- `default_app_config` removed; `AppConfig.default_auto_field = AutoField` to keep historical PKs
- Management command unknown-option rejection
- Test settings: `USE_TZ`, `MIDDLEWARE`, `TEMPLATES`, `ALLOWED_HOSTS`
- Runtime `sql_create_model` tests replaced with a real `tests` app + migrations

Migration history: `trusts.0001_initial` is kept and updated in place with `on_delete=CASCADE` (schema-equivalent to 1.8) and the model’s `related_name` template. Fresh `migrate` applies it. The already-applied path is `scripts/verify-legacy-upgrade.py`. `unique_together` is left as-is.

CI job names: `tests (Python 3.12)`, `tests (Python 3.13)`, `tests (Python 3.14)`, `package`. **Maintainer follow-up:** point branch protection at these names. Do not keep or fake the removed Travis status.

## Tests

Local Python 3.12.3 / Django 6.1.1: **66 tests, OK (1 expected failure)**; `verify-legacy-upgrade.py` passed; isolated wheel import passed.

Added authorization tests: organization isolation, denied access without grant, `:own` settlor-only.

Coverage gaps remaining (anonymous grants, superuser, nested ACL, custom entity model, captured production MySQL/Postgres dump) are in [docs/test-coverage.md](docs/test-coverage.md).

## Out of scope

PyPI publication, final 1.0 tag, permission-model redesign, examples-repo (#16), Windows ACL example (#17). Legacy tag `legacy-pre-modernization` and `docs/legacy-*` are unchanged.

## Design questions

The three implementation choices (Django 6.1 only, Python-level `CASCADE`, keep `unique_together`) stand as previously reviewed; no new Thomas decision requested. Branch-protection status names remain a maintainer follow-up after this revision is green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ad18fe6-7431-48ca-8742-265c11ab3172?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ad18fe6-7431-48ca-8742-265c11ab3172&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

