### PR TITLE
Recover issue #8 APIs and authorization on modern master

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -39,7 +39,17 @@ joined model. That is historical, not a new denial-widening.
 | Decorator `raise_exception=True` | Most decorator tests use `raise_exception=False`. |
 | `TRUSTS_ENTITY_MODEL` swap | Custom entity model is configurable but untested. |
 | Captured production MySQL/Postgres dump | `scripts/verify-legacy-upgrade.py` upgrades a representative 0.10.3-shaped SQLite DB (`trusts.0001_initial` already recorded, historical table DDL). It is not a customer dump and does not replay Django 1.8 contrib tables. |
-| Admin / i18n surfaces | Registered, not exercised. |
+| Admin / i18n surfaces | Core models registered; `auto_modeladmin` opt-in is exercised in `AutoModelAdminTest`. |
+
+## Issue #8 recovery tests (do not close #8)
+
+These must keep passing in addition to the table above:
+
+- `PermittedQuerySetTest` — trustee / group.permissions / role list-direct parity, SQL filter, inactive empty, `get_permission`, grant/revoke
+- `FilterByUserContentPermTest` — create-under-trust, no settlor shortcut, no parent-trust leak, inactive empty, `test_filter_by_user_perm` still discovered
+- `AuthorizationTest` — reader/member denial with no mutation, scoped entity IDs, shared-group `Group.permissions` leak demonstration, shared-group membership requires admin on every trust
+- `TeamViewAuthorizationTest` — member GET/POST 403, admin add, unknown user PK does not mutate
+- `AutoModelAdminTest` — Content and Junction proxies with `auto_modeladmin = True` register; opt-out does not
 
 Do not treat a gap as license to widen access. New grants need an explicit
 test.

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -45,8 +45,8 @@ joined model. That is historical, not a new denial-widening.
 
 These must keep passing in addition to the table above:
 
-- `PermittedQuerySetTest` — trustee / group.permissions / role list-direct parity, SQL filter, inactive empty, `get_permission`, grant/revoke
-- `FilterByUserContentPermTest` — create-under-trust, no settlor shortcut, no parent-trust leak, inactive empty, `test_filter_by_user_perm` still discovered
+- `PermittedQuerySetTest` — trustee / group.permissions / role list-direct parity, SQL filter, inactive empty, `get_permission`, grant/revoke, conditioned names raise `PermissionConditionNotQueryable`
+- `FilterByUserContentPermTest` — create-under-trust, no settlor shortcut, no parent-trust leak, inactive empty, `test_filter_by_user_perm` still discovered, conditioned names raise
 - `AuthorizationTest` — reader/member denial with no mutation, scoped entity IDs, shared-group `Group.permissions` leak demonstration, shared-group membership requires admin on every trust
 - `TeamViewAuthorizationTest` — member GET/POST 403, admin add, unknown user PK does not mutate
 - `AutoModelAdminTest` — Content and Junction proxies with `auto_modeladmin = True` register; opt-out does not

--- a/migrates.md
+++ b/migrates.md
@@ -193,14 +193,15 @@ the 2016 UI.
 | | |
 | --- | --- |
 | Previous | Not on master. #9's `permitted` omitted role grants and hardcoded `auth.Permission`. Example PR #2 reimplemented the JOIN in `projects/query.py`. |
-| New | `Content.objects.permitted(perm, user)` — SQL filter of trustee **or** `Group.permissions` **or** role grants on `content.trust`. Empty for inactive/anonymous. Paginate the QuerySet. Superuser short-circuit is **not** duplicated (Django `ModelBackend`). |
-| Replacement | `Model.objects.permitted('read', user)` or `permitted('app.read_model', user)`. Example list helpers can call this instead of a project-local JOIN. |
+| New | `Content.objects.permitted(perm, user)` — SQL filter of trustee **or** `Group.permissions` **or** role grants on `content.trust`. Empty for inactive/anonymous. Paginate the QuerySet. Superuser short-circuit is **not** duplicated (Django `ModelBackend`). A ``:condition`` suffix (``:own`` or a custom condition) raises ``PermissionConditionNotQueryable``. Conditions stay Python predicates on ``has_perm``; they are not compiled into SQL. |
+| Replacement | `Model.objects.permitted('read', user)` or `permitted('app.read_model', user)`. For ``:own`` / custom conditions, filter unconditioned then `has_perm(..., obj)` per row until conditions are SQL-queryable. |
 | Affected | New callers; Content subclasses inherit `ContentManager`. `Trust.objects` is a `TrustManager` that also inherits `permitted`. |
-| Authorization | List results match `has_perm` on the supported relational paths. Read-only principals are listed only for perms they actually hold. |
+| Authorization | Unconditioned list results match `has_perm` on the supported relational paths. Conditioned requests fail closed (do not silently return every object covered by the underlying grant). |
 
 Migration-bot checklist:
 
-- [ ] Replace Python `[obj for obj in qs if user.has_perm(perm, obj)]` list filters with `.permitted(perm, user)` before pagination.
+- [ ] Replace Python `[obj for obj in qs if user.has_perm(perm, obj)]` list filters with `.permitted(perm, user)` before pagination **only** for unconditioned perms.
+- [ ] Do not call `.permitted('app.read_model:own', user)`; catch `PermissionConditionNotQueryable` or use `has_perm` per object.
 - [ ] Do not treat `permitted` as a superuser "return all" API.
 - [ ] Confirm inactive users get an empty queryset.
 
@@ -209,10 +210,10 @@ Migration-bot checklist:
 | | |
 | --- | --- |
 | Previous | #9 hardcoded `from django.contrib.auth.models import Permission`. |
-| New | Resolves via `get_permission_model()` / `TRUSTS_PERMISSION_MODEL`. Accepts a permission instance, codename, bare action (`read` → `read_<model>`), or dotted code. Strips `:own`. |
+| New | Resolves via `get_permission_model()` / `TRUSTS_PERMISSION_MODEL`. Accepts a permission instance, codename, bare action (`read` → `read_<model>`), or dotted code. May strip a leftover `:condition` when resolving a grant/revoke target. Queryset callers must reject conditions first (`permitted` / `filter_by_user_content_perm` do). |
 | Replacement | `Model.objects.get_permission('read')` or `get_permission('read_model')`. |
-| Affected | `grant` / `revoke` / `permitted` / `filter_by_user_content_perm`. Custom permission models must provide `get_by_natural_key` or `codename` + content type fields. |
-| Authorization | Lookup only; does not grant. |
+| Affected | `grant` / `revoke`. List APIs do not use this helper alone. Custom permission models must provide `get_by_natural_key` or `codename` + content type fields. |
+| Authorization | Lookup only; does not grant. Not a list filter. |
 
 Migration-bot checklist:
 
@@ -239,16 +240,17 @@ Migration-bot checklist:
 | | |
 | --- | --- |
 | Previous | Master has only `filter_by_user_perm(user, **kwargs)` (any trustee or group membership). #9 renamed that method, used parent-trust lookups (`trust__trustees`), ignored `fieldlookup`, and treated settlor as a grant. The #9 test was renamed to `filter_by_user_content_perm` (no `test_` prefix) so discovery failed. |
-| New | **Additional** method. Create-under-trust: Trusts where `user` holds `perm_name` for `content` on **that Trust row** via trustee / group.permissions / role. No parent lookup. No settlor shortcut. `fieldlookup` unused (no existing content required). Inactive → empty. `exclude_root` defaults True. `filter_by_user_perm` and `TrustTest.test_filter_by_user_perm` are unchanged. |
-| Replacement | `Trust.objects.filter_by_user_content_perm(user, Project, 'add_project')` for create-target trust pickers. Keep `filter_by_user_perm` for "trusts this user is attached to". |
+| New | **Additional** method. Create-under-trust: Trusts where `user` holds `perm_name` for `content` on **that Trust row** via trustee / group.permissions / role. No parent lookup. No settlor shortcut. `fieldlookup` unused (no existing content required). Inactive → empty. `exclude_root` defaults True. A ``:condition`` suffix raises ``PermissionConditionNotQueryable`` (same fail-closed rule as `permitted`). `filter_by_user_perm` and `TrustTest.test_filter_by_user_perm` are unchanged. |
+| Replacement | `Trust.objects.filter_by_user_content_perm(user, Project, 'add_project')` for create-target trust pickers. Keep `filter_by_user_perm` for "trusts this user is attached to". Settlor-only create still uses `has_perm(..., :own)` per trust, not this queryset. |
 | Affected | Example `ProjectForm` trust queryset (historical #1). |
-| Authorization | Settlor-only is **not** implied. Create forms must not list every settlor trust. |
+| Authorization | Settlor-only is **not** implied. Conditioned names do not silently return every trust covered by the underlying grant. |
 
 Migration-bot checklist:
 
 - [ ] Do not rename or remove `filter_by_user_perm`.
 - [ ] Update any #9-era `filter_by_user_content_perm(self.user)` (old signature) to the four-argument form.
 - [ ] Confirm settlors without an `add_*` grant are omitted.
+- [ ] Do not pass `:own` / custom conditions to this API.
 - [ ] Keep the test named `test_filter_by_user_perm`.
 
 ### 10. `trusts.authorization` administrative helpers (new)

--- a/migrates.md
+++ b/migrates.md
@@ -169,3 +169,166 @@ auto fields). No intermediate Trusts migration is required.
 - [ ] Migrate a fresh DB (`python -m django migrate --settings=tests.settings`).
 - [ ] Run `python scripts/verify-legacy-upgrade.py` for the already-applied `0001_initial` path.
 - [ ] Verify allow, deny, `:own`, and cross-organization isolation tests.
+
+# Issue #8 recovery (1.0.0.dev0 APIs and authorization)
+
+This record covers the replacement PR for historical #9 / example #1.
+Version remains **1.0.0.dev0**. No 0.11.0, no `TrustGroup` through table,
+and `trusts.0001_initial` is not rewritten. Authorization is stricter than
+the 2016 UI.
+
+## No change to these public call sites
+
+- `User.has_perm` / `User.has_perms` via `TrustModelBackend` (same grant
+  tables: trustee, `Group.permissions` ∩ `Trust.groups`, role ∩ `Trust.groups`)
+- `trusts.decorators.permission_required`, `P`, `K`, `G`, `O`
+- `Trust.objects.get_or_create_settlor_default`, `get_root`,
+  `filter_by_content`, **`filter_by_user_perm`** (name and signature kept)
+- Implicit `Trust.groups` M2M (no through model)
+
+## Changes
+
+### 6. `ContentQuerySet.permitted(perm, user)` (new)
+
+| | |
+| --- | --- |
+| Previous | Not on master. #9's `permitted` omitted role grants and hardcoded `auth.Permission`. Example PR #2 reimplemented the JOIN in `projects/query.py`. |
+| New | `Content.objects.permitted(perm, user)` — SQL filter of trustee **or** `Group.permissions` **or** role grants on `content.trust`. Empty for inactive/anonymous. Paginate the QuerySet. Superuser short-circuit is **not** duplicated (Django `ModelBackend`). |
+| Replacement | `Model.objects.permitted('read', user)` or `permitted('app.read_model', user)`. Example list helpers can call this instead of a project-local JOIN. |
+| Affected | New callers; Content subclasses inherit `ContentManager`. `Trust.objects` is a `TrustManager` that also inherits `permitted`. |
+| Authorization | List results match `has_perm` on the supported relational paths. Read-only principals are listed only for perms they actually hold. |
+
+Migration-bot checklist:
+
+- [ ] Replace Python `[obj for obj in qs if user.has_perm(perm, obj)]` list filters with `.permitted(perm, user)` before pagination.
+- [ ] Do not treat `permitted` as a superuser "return all" API.
+- [ ] Confirm inactive users get an empty queryset.
+
+### 7. `Content.objects.get_permission(perm)` (new)
+
+| | |
+| --- | --- |
+| Previous | #9 hardcoded `from django.contrib.auth.models import Permission`. |
+| New | Resolves via `get_permission_model()` / `TRUSTS_PERMISSION_MODEL`. Accepts a permission instance, codename, bare action (`read` → `read_<model>`), or dotted code. Strips `:own`. |
+| Replacement | `Model.objects.get_permission('read')` or `get_permission('read_model')`. |
+| Affected | `grant` / `revoke` / `permitted` / `filter_by_user_content_perm`. Custom permission models must provide `get_by_natural_key` or `codename` + content type fields. |
+| Authorization | Lookup only; does not grant. |
+
+Migration-bot checklist:
+
+- [ ] Stop importing `auth.Permission` in project grant helpers if `TRUSTS_PERMISSION_MODEL` is set.
+- [ ] Re-run permission resolution tests after swapping the permission model.
+
+### 8. `Content.grant(perm, user)` / `Content.revoke(perm, user)` (new)
+
+| | |
+| --- | --- |
+| Previous | Not on master. #9 `grant` wrote `TrustUserPermission` on `self.trust`. |
+| New | Same write target (`self.trust`). `revoke(perm, user)` deletes that perm; `revoke(None, user)` deletes every trustee row for `user` on that trust. These methods do **not** check the actor; views must call `trusts.authorization.grant_trustee` / `revoke_trustee`. |
+| Replacement | `content.grant('read', user)` / `content.revoke('change', user)`. |
+| Affected | Example `projects.grants.grant_user` / `revoke_user` can delegate here. |
+| Authorization | Unchecked instance methods. Administrative wrapping is mandatory for request handlers. |
+
+Migration-bot checklist:
+
+- [ ] Do not expose `grant`/`revoke` on a `read`-only view.
+- [ ] Use `authorization.grant_trustee(actor, content, user, perm)` for HTTP POSTs.
+
+### 9. `Trust.objects.filter_by_user_content_perm(user, content, perm_name, exclude_root=True, **kwargs)` (new)
+
+| | |
+| --- | --- |
+| Previous | Master has only `filter_by_user_perm(user, **kwargs)` (any trustee or group membership). #9 renamed that method, used parent-trust lookups (`trust__trustees`), ignored `fieldlookup`, and treated settlor as a grant. The #9 test was renamed to `filter_by_user_content_perm` (no `test_` prefix) so discovery failed. |
+| New | **Additional** method. Create-under-trust: Trusts where `user` holds `perm_name` for `content` on **that Trust row** via trustee / group.permissions / role. No parent lookup. No settlor shortcut. `fieldlookup` unused (no existing content required). Inactive → empty. `exclude_root` defaults True. `filter_by_user_perm` and `TrustTest.test_filter_by_user_perm` are unchanged. |
+| Replacement | `Trust.objects.filter_by_user_content_perm(user, Project, 'add_project')` for create-target trust pickers. Keep `filter_by_user_perm` for "trusts this user is attached to". |
+| Affected | Example `ProjectForm` trust queryset (historical #1). |
+| Authorization | Settlor-only is **not** implied. Create forms must not list every settlor trust. |
+
+Migration-bot checklist:
+
+- [ ] Do not rename or remove `filter_by_user_perm`.
+- [ ] Update any #9-era `filter_by_user_content_perm(self.user)` (old signature) to the four-argument form.
+- [ ] Confirm settlors without an `add_*` grant are omitted.
+- [ ] Keep the test named `test_filter_by_user_perm`.
+
+### 10. `trusts.authorization` administrative helpers (new)
+
+| | |
+| --- | --- |
+| Previous | #9 `TeamView`: group membership was enough to add members. Example #1 `ProjectView`: `read` OR `change` then mutate collaborators / `Group.permissions` / `TrustGroup` in `dispatch`. |
+| New | `can_administer_content` requires `change`. `grant_trustee` / `revoke_trustee` / `associate_group_with_trust` / `disassociate_group_from_trust` refuse `read` and unknown IDs (`AuthorizationDenied`, no write). `add_group_member` / `remove_group_member` require `change` on **every** trust that uses the group. `refuse_group_permission_write()` always raises. `create_team` requires trust-row `change` and attaches the new group via `Trust.groups` only. |
+| Replacement | Call these helpers from project settings / team views. Do not copy the 2016 `dispatch` mutations. |
+| Affected | Any UI that adds collaborators, teams, or members. |
+| Authorization | Membership/`read` cannot administer. Shared-group membership is a cross-trust write. |
+
+Migration-bot checklist:
+
+- [ ] Gate POSTs on `change`, not `read` and not `user.groups`.
+- [ ] Resolve submitted user/group PKs; unknown IDs must 403/400 with no write.
+- [ ] Never assign `group.permissions` from a project form.
+- [ ] If a group is used by two trusts, require admin on both before changing members.
+
+### 11. Team views (`trusts.views`, `trusts.urls`)
+
+| | |
+| --- | --- |
+| Previous | #9 views treated membership as admin. Templates: `auth/group_detail.html`, `auth/group_form.html`. |
+| New | Same URL shape (`/teams/new/`, `/teams/<pk>/`). GET/POST require trust-row `change` (or membership-management authority). Create requires a `trust` the actor administers. Add-member form is hidden without authority. Include `trusts.urls` to enable. |
+| Replacement | `path('', include('trusts.urls'))`. Project-settings UI stays in the example app. |
+| Affected | Example #1 wired `trusts.views.team` / `newteam`. |
+| Authorization | Member GET is 403. Invalid user PK does not add a member. |
+
+Migration-bot checklist:
+
+- [ ] Include `trusts.urls` only after granting `change_trust` to intended admins.
+- [ ] Provide a `base.html` (or override the `auth/group_*.html` templates).
+
+### 12. `Meta.auto_modeladmin` (new, milestone two)
+
+| | |
+| --- | --- |
+| Previous | Core `admin.py` registered only Trust / Role / RolePermission / TrustUserPermission. |
+| New | `options.DEFAULT_NAMES` includes `auto_modeladmin`. `AppConfig.ready` registers concrete `Content` / `Junction` subclasses with `auto_modeladmin = True`. Default is False. Already-registered models are skipped. Proxy and abstract subclasses do not re-register content fieldlookups (a proxy Junction must not overwrite the concrete junction's Group lookup). |
+| Replacement | `class Meta: auto_modeladmin = True` on a concrete subclass. |
+| Affected | Project Content/Junction models that want admin without a local `admin.py` line. |
+| Authorization | Django admin permissions still apply; this only registers the class. |
+
+Migration-bot checklist:
+
+- [ ] Set the flag only on concrete, non-abstract models you want in `/admin/`.
+- [ ] Do not set it on `Trust` (already registered).
+
+### 13. Schema: no `TrustGroup`
+
+| | |
+| --- | --- |
+| Previous | #9 added `TrustGroup` by editing `0001_initial` and bumped the package to 0.11.0. |
+| New | Implicit `Trust.groups` M2M is retained. No forward through-table migration. Package stays `1.0.0.dev0`. |
+| Replacement | `trust.groups.add(group)` / `.remove(group)`. |
+| Affected | Historical example #1 `TrustGroup(...)` callers. |
+| Authorization | Association is per-trust. `Group.permissions` remains global (see policy note in the PR). |
+
+Migration-bot checklist:
+
+- [ ] Do not fake or re-run `0001_initial` to pick up a through table.
+- [ ] Fresh migrate and `scripts/verify-legacy-upgrade.py` still see only `{0001_initial}`.
+- [ ] Replace `TrustGroup` writes with `trust.groups.add`.
+
+## Policy not implemented (needs Thomas)
+
+Per-trust group permission *levels* (group G has `change` on trust A and
+only `read` on trust B) and per-trust group *membership* are not in the
+schema. This PR refuses to fake them with `Group.permissions` / shared
+`Group.user_set` writes. A redesign (`TrustGroupPermission` or similar)
+must not merge without an explicit go-ahead.
+
+## Migration-bot summary (issue #8)
+
+- [ ] Adopt `permitted` / `grant` / `revoke` / `filter_by_user_content_perm` instead of #9 copies.
+- [ ] Keep `filter_by_user_perm` and `test_filter_by_user_perm`.
+- [ ] Wrap mutations with `trusts.authorization` (`change`, scoped IDs).
+- [ ] Do not write `Group.permissions` from a project form.
+- [ ] Do not add `TrustGroup` or edit `0001_initial`.
+- [ ] Set `auto_modeladmin = True` only where you want automatic admin.
+- [ ] Leave package version at `1.0.0.dev0`.
+

--- a/migrates.md
+++ b/migrates.md
@@ -288,7 +288,7 @@ Migration-bot checklist:
 | | |
 | --- | --- |
 | Previous | Core `admin.py` registered only Trust / Role / RolePermission / TrustUserPermission. |
-| New | `options.DEFAULT_NAMES` includes `auto_modeladmin`. `AppConfig.ready` registers concrete `Content` / `Junction` subclasses with `auto_modeladmin = True`. Default is False. Already-registered models are skipped. Proxy and abstract subclasses do not re-register content fieldlookups (a proxy Junction must not overwrite the concrete junction's Group lookup). |
+| New | `options.DEFAULT_NAMES` includes `auto_modeladmin`. `AppConfig.ready` registers concrete `Content` / `Junction` subclasses with `auto_modeladmin = True` **only when `django.contrib.admin` is installed**. Default is False. Already-registered models are skipped. Proxy and abstract subclasses do not re-register content fieldlookups (a proxy Junction must not overwrite the concrete junction's Group lookup). |
 | Replacement | `class Meta: auto_modeladmin = True` on a concrete subclass. |
 | Affected | Project Content/Junction models that want admin without a local `admin.py` line. |
 | Authorization | Django admin permissions still apply; this only registers the class. |

--- a/tests/models.py
+++ b/tests/models.py
@@ -29,3 +29,27 @@ class TestGroupJunction(Junction):
             ('admin', ('read_group', 'add_group', 'change_group', 'add_topic_to_group')),
             ('write', ('read_group', 'change_group', 'add_topic_to_group')),
         )
+
+
+class AutoAdminCategory(Category):
+    """Proxy Content subclass opting into auto ModelAdmin registration."""
+
+    class Meta:
+        proxy = True
+        auto_modeladmin = True
+
+
+class ManualAdminCategory(Category):
+    """Proxy Content subclass that must stay unregistered."""
+
+    class Meta:
+        proxy = True
+        auto_modeladmin = False
+
+
+class AutoAdminJunction(TestGroupJunction):
+    """Proxy Junction subclass opting into auto ModelAdmin registration."""
+
+    class Meta:
+        proxy = True
+        auto_modeladmin = True

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,3 +1,5 @@
+from os.path import dirname, join
+
 SECRET_KEY = '01)%8q7ub=+yw7^#dz5s!6kkff6%al5f)_ayvep9_b&w1q-dvs'
 
 USE_TZ = True
@@ -33,6 +35,9 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'APP_DIRS': True,
+        'DIRS': [
+            join(dirname(__file__), 'templates'),
+        ],
         'OPTIONS': {
             'context_processors': [
                 'django.template.context_processors.request',

--- a/tests/templates/base.html
+++ b/tests/templates/base.html
@@ -1,0 +1,6 @@
+<html>
+    <body>
+        {% block content %}
+        {% endblock %}
+    </body>
+</html>

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,1 +1,5 @@
-urlpatterns = []
+from django.urls import include, path
+
+urlpatterns = [
+    path('', include('trusts.urls')),
+]

--- a/trusts/admin.py
+++ b/trusts/admin.py
@@ -1,8 +1,28 @@
 from django.contrib import admin
-from trusts.models import Trust, Role, RolePermission, TrustUserPermission
+from django.apps import apps as django_apps
+
+from trusts.models import Content, Junction, Trust, Role, RolePermission, TrustUserPermission
 
 admin.site.register(Trust, admin.ModelAdmin)
 admin.site.register(Role, admin.ModelAdmin)
 admin.site.register(RolePermission, admin.ModelAdmin)
 admin.site.register(TrustUserPermission, admin.ModelAdmin)
 
+
+def register_auto_modeladmins(admin_site=None):
+    """Register concrete Content/Junction subclasses with ``auto_modeladmin=True``.
+
+    Opt-in only. Core models stay explicitly registered above. Already
+    registered models are skipped. Safe to call more than once.
+    """
+    site = admin_site if admin_site is not None else admin.site
+    for model in django_apps.get_models():
+        if model._meta.abstract:
+            continue
+        if not getattr(model._meta, 'auto_modeladmin', False):
+            continue
+        if not issubclass(model, (Content, Junction)):
+            continue
+        if site.is_registered(model):
+            continue
+        site.register(model)

--- a/trusts/apps.py
+++ b/trusts/apps.py
@@ -7,3 +7,7 @@ class AppConfig(DjangoAppConfig):
     label = 'trusts'
     # Preserve the historical AutoField primary keys from 0001_initial.
     default_auto_field = 'django.db.models.AutoField'
+
+    def ready(self):
+        from trusts.admin import register_auto_modeladmins
+        register_auto_modeladmins()

--- a/trusts/apps.py
+++ b/trusts/apps.py
@@ -9,5 +9,10 @@ class AppConfig(DjangoAppConfig):
     default_auto_field = 'django.db.models.AutoField'
 
     def ready(self):
-        from trusts.admin import register_auto_modeladmins
-        register_auto_modeladmins()
+        # admin.py registers core ModelAdmins at import. Only load it when
+        # django.contrib.admin is installed so a wheel import without admin
+        # (CI verify-wheel-install) still starts.
+        from django.apps import apps as django_apps
+        if django_apps.is_installed('django.contrib.admin'):
+            from trusts.admin import register_auto_modeladmins
+            register_auto_modeladmins()

--- a/trusts/authorization.py
+++ b/trusts/authorization.py
@@ -1,0 +1,252 @@
+"""Administrative authority for trust-scoped mutations.
+
+Ordinary ``read`` and mere group membership are not enough to mutate
+collaborators, group associations, or team membership. Callers must use
+these helpers (or equivalent ``change`` checks) before writing.
+
+``Group.permissions`` is a global Django M2M. Helpers here never write it.
+Associating a group with a trust is ``Trust.groups.add`` only. Genuine
+per-trust group permission *levels* are not expressible with the current
+schema; that redesign is flagged for Thomas and is not implemented here.
+
+``Group.user_set`` is also global. Adding a member to a group that two
+trusts share grants that group's rights in both. Membership changes
+therefore require administrative ``change`` on every trust that uses the
+group.
+"""
+
+from django.core.exceptions import PermissionDenied
+
+from trusts import get_entity_model, get_group_model
+from trusts.query import is_active_principal, trust_grant_q
+from trusts.models import Trust
+
+
+class AuthorizationDenied(PermissionDenied):
+    """Raised when a mutation is refused. Callers must not write after this."""
+
+
+def content_permission_code(model, action):
+    return '%s.%s_%s' % (model._meta.app_label, action, model._meta.model_name)
+
+
+def can_read_content(user, obj):
+    if not is_active_principal(user):
+        return False
+    return user.has_perm(content_permission_code(obj.__class__, 'read'), obj)
+
+
+def can_administer_content(user, obj):
+    """True only when ``user`` has ``change`` on ``obj``.
+
+    ``read`` and group membership alone are insufficient.
+    """
+    if not is_active_principal(user):
+        return False
+    return user.has_perm(content_permission_code(obj.__class__, 'change'), obj)
+
+
+def has_trust_row_perm(user, trust, perm):
+    """Grant on this Trust row (trustee / group.permissions / role).
+
+    This does **not** follow ``Trust.trust`` parent resolution used by
+    ``has_perm`` when the object itself is a ``Trust``. Create-under-trust
+    and trust-row administration use this check.
+    """
+    if not is_active_principal(user) or trust is None:
+        return False
+    permission = Trust.objects.get_permission(perm) if isinstance(perm, str) else perm
+    return Trust.objects.filter(pk=trust.pk).filter(
+        trust_grant_q(user, permission)
+    ).exists()
+
+
+def can_administer_trust(user, trust, via_content=None):
+    """Administrative ``change`` on a Trust.
+
+    If ``via_content`` is given, the actor must have ``change`` on that
+    content and the content must belong to ``trust``. Otherwise the actor
+    needs a ``change_trust`` grant on the trust row itself.
+    """
+    if via_content is not None:
+        if getattr(via_content, 'trust_id', None) != trust.pk:
+            return False
+        return can_administer_content(user, via_content)
+    return has_trust_row_perm(user, trust, 'change')
+
+
+def trusts_using_group(group):
+    return Trust.objects.filter(groups=group).distinct()
+
+
+def can_manage_group_membership(user, group, via_content=None):
+    """True when ``user`` can change members of ``group``.
+
+    Membership is global. The actor must administer every trust that
+    currently uses the group. An unused group has no trust scope and
+    cannot be managed here. Being a member of the group is not enough.
+    """
+    if not is_active_principal(user) or group is None:
+        return False
+    trusts = list(trusts_using_group(group))
+    if not trusts:
+        return False
+    return all(
+        can_administer_trust(
+            user,
+            trust,
+            via_content=via_content if (
+                via_content is not None and getattr(via_content, 'trust_id', None) == trust.pk
+            ) else None,
+        )
+        for trust in trusts
+    )
+
+
+def _require(condition, message):
+    if not condition:
+        raise AuthorizationDenied(message)
+
+
+def resolve_entity_id(model, pk, queryset=None):
+    """Resolve a submitted primary key against an authorized queryset."""
+    qs = queryset if queryset is not None else model._default_manager.all()
+    try:
+        return qs.get(pk=pk)
+    except (model.DoesNotExist, ValueError, TypeError):
+        raise AuthorizationDenied('Submitted entity is outside the authorized scope.')
+
+
+def grant_trustee(actor, content, user, perm):
+    """Grant a TrustUserPermission on ``content.trust``. Requires ``change``."""
+    _require(can_administer_content(actor, content),
+             'change permission is required to grant collaborators.')
+    Entity = get_entity_model()
+    if not isinstance(user, Entity):
+        user = resolve_entity_id(Entity, user)
+    content.grant(perm, user)
+    return user
+
+
+def revoke_trustee(actor, content, user, perm=None):
+    """Revoke trustee rows on ``content.trust`` only. Requires ``change``."""
+    _require(can_administer_content(actor, content),
+             'change permission is required to revoke collaborators.')
+    Entity = get_entity_model()
+    scope = Entity._default_manager.filter(
+        trustpermissions__trust=content.trust
+    ).distinct()
+    if not isinstance(user, Entity):
+        user = resolve_entity_id(Entity, user, queryset=scope)
+    elif not scope.filter(pk=user.pk).exists():
+        raise AuthorizationDenied('Submitted entity is outside the authorized scope.')
+    content.revoke(perm, user)
+    return user
+
+
+def associate_group_with_trust(actor, content, group):
+    """Attach ``group`` to ``content.trust``. Does not write Group.permissions."""
+    _require(can_administer_content(actor, content),
+             'change permission is required to associate a team.')
+    Group = get_group_model()
+    if not isinstance(group, Group):
+        group = resolve_entity_id(Group, group)
+    content.trust.groups.add(group)
+    return group
+
+
+def disassociate_group_from_trust(actor, content, group):
+    """Detach ``group`` from ``content.trust`` only. Requires ``change``."""
+    _require(can_administer_content(actor, content),
+             'change permission is required to remove a team.')
+    Group = get_group_model()
+    scope = content.trust.groups.all()
+    if not isinstance(group, Group):
+        group = resolve_entity_id(Group, group, queryset=scope)
+    elif not scope.filter(pk=group.pk).exists():
+        raise AuthorizationDenied('Submitted entity is outside the authorized scope.')
+    content.trust.groups.remove(group)
+    return group
+
+
+def refuse_group_permission_write():
+    """Group.permissions is global; never treat it as project-local."""
+    raise AuthorizationDenied(
+        'Group.permissions is a global Django relation, not a per-trust '
+        'setting. Associate the group with the trust (Trust.groups) and '
+        'use Role permissions or TrustUserPermission. Genuine per-trust '
+        'group rights need a model redesign and are not implemented.'
+    )
+
+
+def add_group_member(actor, group, user, via_content=None):
+    """Add ``user`` to ``group``. Requires admin on every trust using the group."""
+    Group = get_group_model()
+    if not isinstance(group, Group):
+        group = resolve_entity_id(Group, group)
+    _require(
+        can_manage_group_membership(actor, group, via_content=via_content),
+        'Administrative change on every trust using this group is required '
+        'to add members. Membership or read alone is not enough.',
+    )
+    Entity = get_entity_model()
+    if not isinstance(user, Entity):
+        user = resolve_entity_id(Entity, user)
+    group.user_set.add(user)
+    return user
+
+
+def remove_group_member(actor, group, user, via_content=None):
+    """Remove ``user`` from ``group``. Same authority as ``add_group_member``."""
+    Group = get_group_model()
+    if not isinstance(group, Group):
+        group = resolve_entity_id(Group, group)
+    _require(
+        can_manage_group_membership(actor, group, via_content=via_content),
+        'Administrative change on every trust using this group is required '
+        'to remove members. Membership or read alone is not enough.',
+    )
+    Entity = get_entity_model()
+    scope = group.user_set.all()
+    if not isinstance(user, Entity):
+        user = resolve_entity_id(Entity, user, queryset=scope)
+    elif not scope.filter(pk=user.pk).exists():
+        raise AuthorizationDenied('Submitted entity is outside the authorized scope.')
+    group.user_set.remove(user)
+    return user
+
+
+def create_team(actor, trust, name, via_content=None):
+    """Create a Group, attach it to ``trust``, and add ``actor`` as a member."""
+    _require(
+        can_administer_trust(actor, trust, via_content=via_content),
+        'change permission is required to create a team on this trust.',
+    )
+    Group = get_group_model()
+    group = Group.objects.create(name=name)
+    trust.groups.add(group)
+    group.user_set.add(actor)
+    return group
+
+
+# Imported by views; keep unused-import checkers from dropping the TUP symbol
+# if a caller introspects this module for mutation targets.
+__all__ = [
+    'AuthorizationDenied',
+    'add_group_member',
+    'associate_group_with_trust',
+    'can_administer_content',
+    'can_administer_trust',
+    'can_manage_group_membership',
+    'can_read_content',
+    'content_permission_code',
+    'create_team',
+    'disassociate_group_from_trust',
+    'grant_trustee',
+    'has_trust_row_perm',
+    'refuse_group_permission_write',
+    'remove_group_member',
+    'resolve_entity_id',
+    'revoke_trustee',
+    'trusts_using_group',
+]

--- a/trusts/models.py
+++ b/trusts/models.py
@@ -4,15 +4,81 @@ from django.db.models import signals, Q, options
 from django.utils.translation import gettext_lazy as _
 
 from trusts import ENTITY_MODEL_NAME, PERMISSION_MODEL_NAME, GROUP_MODEL_NAME, \
-                    DEFAULT_SETTLOR, ALLOW_NULL_SETTLOR, ROOT_PK, utils
+                    DEFAULT_SETTLOR, ALLOW_NULL_SETTLOR, ROOT_PK, \
+                    get_permission_model, utils
+from trusts.query import is_active_principal, trust_grant_q
 
 
 options.DEFAULT_NAMES += ('roles', 'permission_conditions',
-                          'content_roles', 'content_permission_conditions'
+                          'content_roles', 'content_permission_conditions',
+                          'auto_modeladmin',
     )
 
 
-class TrustManager(models.Manager):
+def resolve_content_permission(model, perm):
+    """Resolve ``perm`` via ``TRUSTS_PERMISSION_MODEL``, not hardcoded auth.Permission.
+
+    Accepts a permission instance, a codename (``read_category``), a bare
+    action (``read`` → ``read_<model>``), or a dotted code
+    (``app.read_category``). Condition suffixes (``:own``) are stripped.
+    """
+    Permission = get_permission_model()
+    if isinstance(perm, Permission):
+        return perm
+
+    app_label = model._meta.app_label
+    model_name = model._meta.model_name
+    perm = str(perm)
+    if '.' in perm:
+        try:
+            applabel, modelname, action, _cond = utils.parse_perm_code(perm)
+            perm = '%s_%s' % (action, modelname)
+            app_label = applabel
+            model_name = modelname
+        except ValueError:
+            app_label, perm = perm.split('.', 1)
+    if ':' in perm:
+        perm = perm.split(':', 1)[0]
+    if not perm.endswith('_' + model_name) and '_' not in perm:
+        perm = '%s_%s' % (perm, model_name)
+
+    manager = Permission.objects
+    if hasattr(manager, 'get_by_natural_key'):
+        return manager.get_by_natural_key(perm, app_label.lower(), model_name)
+    return manager.get(
+        codename=perm,
+        content_type__app_label=app_label.lower(),
+        content_type__model=model_name,
+    )
+
+
+class ContentQuerySet(models.QuerySet):
+    def permitted(self, perm, user):
+        """Content the user may access via trustee, group, or role grants.
+
+        SQL-filtered (paginate the returned QuerySet). Empty for inactive
+        or anonymous principals. Role-derived grants are included so list
+        results match ``has_perm`` on the supported relational paths.
+        Superuser short-circuit is not duplicated (Django ModelBackend).
+        """
+        if not is_active_principal(user):
+            return self.none()
+        permission = resolve_content_permission(self.model, perm)
+        return self.filter(trust_grant_q(user, permission, trust_fk='trust')).distinct()
+
+
+class ContentManager(models.Manager):
+    def get_queryset(self):
+        return ContentQuerySet(self.model, using=self._db)
+
+    def get_permission(self, perm):
+        return resolve_content_permission(self.model, perm)
+
+    def permitted(self, perm, user):
+        return self.get_queryset().permitted(perm, user)
+
+
+class TrustManager(ContentManager):
     def get_or_create_settlor_default(self, settlor, defaults={}, **kwargs):
         if 'trust' in kwargs:
             raise TypeError('"%s" are invalid keyword arguments' % 'trust')
@@ -63,6 +129,45 @@ class TrustManager(models.Manager):
 
         return self.filter(Q(groups__user=user) | Q(trustees__entity=user), **kwargs)
 
+    def filter_by_user_content_perm(self, user, content, perm_name, exclude_root=True, **kwargs):
+        """Return Trusts under which ``user`` may exercise ``perm_name``.
+
+        Create-under-trust semantics (verified, not inherited from #9):
+
+        - A Trust is included when ``user`` has ``perm_name`` for ``content``
+          via trustee, ``Group.permissions``, or role grants **on that Trust
+          row**.
+        - Parent-trust relations (``trust__trustees`` / ``trust__groups``)
+          are not queried. ``#9`` did that accidentally.
+        - Settlor identity is not a grant. Use ``has_perm(..., :own)`` for
+          settlor-only operations.
+        - ``fieldlookup`` from ``Content.get_content_fieldlookup`` is unused:
+          this API filters Trust rows by grants, not by existing content
+          rows. A Trust with no content yet can still be a create target.
+        - Inactive / anonymous principals yield an empty queryset.
+        - ``exclude_root=True`` drops ``TRUSTS_ROOT_PK`` (typical for
+          organization content).
+        - ``filter_by_user_perm`` is unchanged (membership/trustee, no
+          permission name).
+        """
+        if 'group__user' in kwargs:
+            raise TypeError('"%s" are invalid keyword arguments' % 'group__user')
+
+        if not is_active_principal(user):
+            return self.none()
+
+        if not isinstance(content, type):
+            content = content.__class__
+
+        if not Content.is_content_model(content):
+            return self.none()
+
+        permission = resolve_content_permission(content, perm_name)
+        qs = self.filter(trust_grant_q(user, permission), **kwargs)
+        if exclude_root and ROOT_PK is not None:
+            qs = qs.exclude(pk=ROOT_PK)
+        return qs.distinct()
+
 
 class ReadonlyFieldsMixin(object):
     def _readonly_attname(self, field_name):
@@ -99,6 +204,7 @@ class ReadonlyFieldsMixin(object):
 class Content(ReadonlyFieldsMixin, models.Model):
     trust = models.ForeignKey('trusts.Trust', related_name='%(app_label)s_%(class)s_content',
                 default=ROOT_PK, null=False, blank=False, on_delete=models.CASCADE)
+    objects = ContentManager()
     _contents = {}
     _conditions = {}
 
@@ -106,6 +212,24 @@ class Content(ReadonlyFieldsMixin, models.Model):
         abstract = True
         default_permissions = ('add', 'change', 'delete', 'read',)
         permission_conditions = ()
+        auto_modeladmin = False
+
+    def grant(self, perm, user):
+        """Create a TrustUserPermission on this content's authorizing trust."""
+        permission = type(self).objects.get_permission(perm)
+        TrustUserPermission.objects.get_or_create(
+            trust=self.trust, entity=user, permission=permission
+        )
+
+    def revoke(self, perm, user):
+        """Remove TrustUserPermission rows on this content's trust.
+
+        ``perm=None`` removes every trustee grant for ``user`` on this trust.
+        """
+        qs = TrustUserPermission.objects.filter(trust=self.trust, entity=user)
+        if perm is not None:
+            qs = qs.filter(permission=type(self).objects.get_permission(perm))
+        qs.delete()
 
     @staticmethod
     def register_permission_condition(klass, cond_code, func):
@@ -255,6 +379,10 @@ class Junction(ReadonlyFieldsMixin, models.Model):
 
 
 def register_content_junction(sender, **kwargs):
+    # Proxy subclasses share the concrete table and must not overwrite the
+    # content/junction fieldlookup registered for that table.
+    if sender._meta.proxy or sender._meta.abstract:
+        return
     if issubclass(sender, Junction):
         Junction.register_junction(sender)
     elif issubclass(sender, Content):

--- a/trusts/models.py
+++ b/trusts/models.py
@@ -15,12 +15,42 @@ options.DEFAULT_NAMES += ('roles', 'permission_conditions',
     )
 
 
+class PermissionConditionNotQueryable(ValueError):
+    """Raised when a SQL list/create filter is given a ``:condition`` suffix.
+
+    Conditions (``:own`` and custom ``permission_conditions``) are Python
+    predicates evaluated by ``User.has_perm``. They are not compiled into
+    SQL. ``permitted`` and ``filter_by_user_content_perm`` refuse them so
+    they cannot silently over-grant the underlying permission.
+    """
+
+
+def permission_has_condition(perm):
+    """True when ``perm`` is a string with a ``:condition`` suffix."""
+    return isinstance(perm, str) and ':' in perm
+
+
+def reject_queryable_condition(perm, api_name):
+    if permission_has_condition(perm):
+        raise PermissionConditionNotQueryable(
+            '%s does not support permission conditions (%r). '
+            'Conditions are evaluated by has_perm, not SQL. Use the '
+            'unconditioned permission for the queryset and apply '
+            'has_perm(..., obj) per object until conditions are '
+            'SQL-queryable.' % (api_name, perm)
+        )
+
+
 def resolve_content_permission(model, perm):
     """Resolve ``perm`` via ``TRUSTS_PERMISSION_MODEL``, not hardcoded auth.Permission.
 
     Accepts a permission instance, a codename (``read_category``), a bare
     action (``read`` → ``read_<model>``), or a dotted code
-    (``app.read_category``). Condition suffixes (``:own``) are stripped.
+    (``app.read_category``).
+
+    Queryset APIs must call ``reject_queryable_condition`` first. This
+    helper may still strip a leftover ``:condition`` when resolving a
+    grant/revoke target; it must not be used alone to filter lists.
     """
     Permission = get_permission_model()
     if isinstance(perm, Permission):
@@ -60,7 +90,12 @@ class ContentQuerySet(models.QuerySet):
         or anonymous principals. Role-derived grants are included so list
         results match ``has_perm`` on the supported relational paths.
         Superuser short-circuit is not duplicated (Django ModelBackend).
+
+        A ``:condition`` suffix raises ``PermissionConditionNotQueryable``.
+        Conditions are not SQL-queryable; refusing them avoids over-granting
+        the underlying permission.
         """
+        reject_queryable_condition(perm, 'ContentQuerySet.permitted')
         if not is_active_principal(user):
             return self.none()
         permission = resolve_content_permission(self.model, perm)
@@ -140,7 +175,7 @@ class TrustManager(ContentManager):
         - Parent-trust relations (``trust__trustees`` / ``trust__groups``)
           are not queried. ``#9`` did that accidentally.
         - Settlor identity is not a grant. Use ``has_perm(..., :own)`` for
-          settlor-only operations.
+          settlor-only operations (not this queryset).
         - ``fieldlookup`` from ``Content.get_content_fieldlookup`` is unused:
           this API filters Trust rows by grants, not by existing content
           rows. A Trust with no content yet can still be a create target.
@@ -149,10 +184,15 @@ class TrustManager(ContentManager):
           organization content).
         - ``filter_by_user_perm`` is unchanged (membership/trustee, no
           permission name).
+        - A ``:condition`` suffix raises ``PermissionConditionNotQueryable``
+          (same fail-closed rule as ``permitted``).
         """
         if 'group__user' in kwargs:
             raise TypeError('"%s" are invalid keyword arguments' % 'group__user')
 
+        reject_queryable_condition(
+            perm_name, 'Trust.objects.filter_by_user_content_perm'
+        )
         if not is_active_principal(user):
             return self.none()
 

--- a/trusts/query.py
+++ b/trusts/query.py
@@ -1,0 +1,49 @@
+"""SQL grant filters shared by list APIs and trust-row checks.
+
+These Q objects JOIN the same trustee / group.permissions / role tables
+that ``TrustModelBackend.get_all_permissions`` reads. Callers must apply
+them on a QuerySet (then paginate). They are not Python predicates.
+"""
+
+from django.db.models import Q
+
+
+def is_active_principal(user):
+    """Match ``User.has_perm``: anonymous and inactive principals are denied.
+
+    Superuser short-circuit on ``has_perm`` is a Django ``ModelBackend``
+    behavior and is not duplicated in SQL list filters.
+    """
+    if user is None:
+        return False
+    if getattr(user, 'is_anonymous', False):
+        return False
+    if not getattr(user, 'is_authenticated', True):
+        return False
+    if not getattr(user, 'is_active', False):
+        return False
+    return True
+
+
+def trust_grant_q(user, permission, trust_fk=''):
+    """Return a Q matching trustee, group.permissions, and role-derived grants.
+
+    ``trust_fk`` is the lookup prefix to the Trust row:
+    - ``''`` filters ``Trust`` rows themselves (create-under-trust).
+    - ``'trust'`` filters Content rows via ``Content.trust``.
+    """
+    prefix = ('%s__' % trust_fk) if trust_fk else ''
+    return (
+        Q(**{
+            '%strustees__entity' % prefix: user,
+            '%strustees__permission' % prefix: permission,
+        }) |
+        Q(**{
+            '%sgroups__user' % prefix: user,
+            '%sgroups__permissions' % prefix: permission,
+        }) |
+        Q(**{
+            '%sgroups__user' % prefix: user,
+            '%sgroups__roles__permissions' % prefix: permission,
+        })
+    )

--- a/trusts/templates/auth/group_detail.html
+++ b/trusts/templates/auth/group_detail.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>{{ object }}</h1>
+<h1>Members</h1>
+<div>
+{% for u in object.user_set.all %}
+{{ u }}<br>
+{% endfor %}
+</div>
+{% if can_manage_members %}
+<form method="post">
+    Add member: {{ adduserform.user }}
+    {% csrf_token %}
+    <input type="submit" value="Add">
+</form>
+{% endif %}
+{% endblock %}

--- a/trusts/templates/auth/group_form.html
+++ b/trusts/templates/auth/group_form.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1>Create new team</h1>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="Create">
+</form>
+{% endblock %}

--- a/trusts/test_issue8.py
+++ b/trusts/test_issue8.py
@@ -23,7 +23,13 @@ from trusts.authorization import (
     refuse_group_permission_write,
     revoke_trustee,
 )
-from trusts.models import Role, Trust, TrustUserPermission
+from trusts.models import (
+    Content,
+    PermissionConditionNotQueryable,
+    Role,
+    Trust,
+    TrustUserPermission,
+)
 from trusts.tests import (
     ContentModelMixin,
     create_test_users,
@@ -120,6 +126,33 @@ class PermittedQuerySetTest(Issue8FixtureMixin, TestCase):
         reload_test_users(self)
         self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_change), self.content))
 
+    def test_conditioned_perm_fails_closed(self):
+        """A :condition must not silently return every unconditioned grant.
+
+        Reproduces the #20 review: register an always-false condition,
+        grant the underlying read, then compare has_perm vs permitted.
+        """
+        Content.register_permission_condition(
+            Category, 'never', lambda user, perm, obj: False
+        )
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_read
+        ).save()
+        reload_test_users(self)
+        unconditioned = self.get_perm_code(self.perm_read)
+        conditioned = '%s:never' % unconditioned
+        self.assertTrue(self.user.has_perm(unconditioned, self.content))
+        self.assertFalse(self.user.has_perm(conditioned, self.content))
+        with self.assertRaises(PermissionConditionNotQueryable):
+            Category.objects.permitted(conditioned, self.user)
+        with self.assertRaises(PermissionConditionNotQueryable):
+            Category.objects.permitted('read_category:own', self.user)
+        # Unconditioned path still lists the granted row only.
+        self.assertEqual(
+            set(Category.objects.permitted(unconditioned, self.user).values_list('pk', flat=True)),
+            {self.content.pk},
+        )
+
 
 class FilterByUserContentPermTest(Issue8FixtureMixin, TestCase):
     def test_filter_by_user_perm_name_still_discovered(self):
@@ -185,6 +218,29 @@ class FilterByUserContentPermTest(Issue8FixtureMixin, TestCase):
             self.user, Category, 'add_category'
         )
         self.assertIn(self.org.pk, trusts.values_list('pk', flat=True))
+
+    def test_conditioned_perm_fails_closed(self):
+        Content.register_permission_condition(
+            Category, 'never', lambda user, perm, obj: False
+        )
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_add
+        ).save()
+        reload_test_users(self)
+        unconditioned = self.get_perm_code(self.perm_add)
+        conditioned = '%s:never' % unconditioned
+        with self.assertRaises(PermissionConditionNotQueryable):
+            Trust.objects.filter_by_user_content_perm(
+                self.user, Category, conditioned
+            )
+        with self.assertRaises(PermissionConditionNotQueryable):
+            Trust.objects.filter_by_user_content_perm(
+                self.user, Category, 'add_category:own'
+            )
+        trusts = Trust.objects.filter_by_user_content_perm(
+            self.user, Category, unconditioned, exclude_root=True
+        )
+        self.assertEqual(set(trusts.values_list('pk', flat=True)), {self.org.pk})
 
 
 class AuthorizationTest(Issue8FixtureMixin, TestCase):

--- a/trusts/test_issue8.py
+++ b/trusts/test_issue8.py
@@ -1,0 +1,402 @@
+"""Recovery tests for issue #8: list APIs, authorization, auto_modeladmin.
+
+Does not close #8. Covers the core milestone: APIs, auth holes, cross-trust
+group scope, inactive principals, and opt-in admin registration.
+"""
+
+from django.contrib import admin
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
+from django.test import Client, TestCase
+
+from trusts.admin import register_auto_modeladmins
+from trusts.authorization import (
+    AuthorizationDenied,
+    add_group_member,
+    associate_group_with_trust,
+    can_administer_content,
+    can_manage_group_membership,
+    create_team,
+    disassociate_group_from_trust,
+    grant_trustee,
+    refuse_group_permission_write,
+    revoke_trustee,
+)
+from trusts.models import Role, Trust, TrustUserPermission
+from trusts.tests import (
+    ContentModelMixin,
+    create_test_users,
+    get_or_create_root_user,
+    reload_test_users,
+)
+from tests.models import AutoAdminCategory, AutoAdminJunction, Category, ManualAdminCategory
+
+
+class Issue8FixtureMixin(ContentModelMixin):
+    def setUp(self):
+        super(Issue8FixtureMixin, self).setUp()
+        self.org = Trust(settlor=self.user, trust=Trust.objects.get_root(), title='Org A')
+        self.org.save()
+        self.org_b = Trust(settlor=self.user1, trust=Trust.objects.get_root(), title='Org B')
+        self.org_b.save()
+        self.content = self.create_content(self.org)
+        self.content_b = self.create_content(self.org_b)
+
+
+class PermittedQuerySetTest(Issue8FixtureMixin, TestCase):
+    def _direct_pks(self, perm, user):
+        return set(
+            obj.pk for obj in Category.objects.all()
+            if user.has_perm(self.get_perm_code(perm), obj)
+        )
+
+    def _assert_list_direct_parity(self, perm, user):
+        qs = Category.objects.permitted(perm.codename, user)
+        self.assertEqual(set(qs.values_list('pk', flat=True)), self._direct_pks(perm, user))
+        sql = str(qs.query)
+        self.assertTrue(
+            'JOIN' in sql.upper() or 'EXISTS' in sql.upper() or 'trusts_trustuserpermission' in sql,
+            'permitted() must filter in SQL, not in Python. SQL was: %s' % sql,
+        )
+        # Pagination wraps the filtered QuerySet.
+        self.assertEqual(list(qs[:50]), list(qs))
+
+    def test_trustee_list_direct_parity_and_sql(self):
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_read
+        ).save()
+        reload_test_users(self)
+        self._assert_list_direct_parity(self.perm_read, self.user)
+        self.assertIn(self.content.pk, Category.objects.permitted('read', self.user).values_list('pk', flat=True))
+        self.assertNotIn(self.content_b.pk, Category.objects.permitted('read', self.user).values_list('pk', flat=True))
+
+    def test_group_permissions_path(self):
+        self.perm_read.group_set.add(self.group)
+        self.user.groups.add(self.group)
+        self.org.groups.add(self.group)
+        reload_test_users(self)
+        self._assert_list_direct_parity(self.perm_read, self.user)
+
+    def test_role_derived_grants_included(self):
+        call_command('update_roles_permissions')
+        self.group.user_set.add(self.user)
+        self.org.groups.add(self.group)
+        Role.objects.get(name='public').groups.add(self.group)
+        reload_test_users(self)
+        self.assertTrue(self.user.has_perm(self.get_perm_code(self.perm_read), self.content))
+        qs = Category.objects.permitted('read_category', self.user)
+        self.assertIn(self.content.pk, qs.values_list('pk', flat=True))
+        self._assert_list_direct_parity(self.perm_read, self.user)
+
+    def test_inactive_principal_empty(self):
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_read
+        ).save()
+        self.user.is_active = False
+        self.user.save()
+        reload_test_users(self)
+        self.assertFalse(Category.objects.permitted('read', self.user).exists())
+        self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_read), self.content))
+
+    def test_get_permission_uses_configured_model(self):
+        from django.contrib.auth.models import Permission as AuthPermission
+        from trusts import get_permission_model
+
+        self.assertIs(get_permission_model(), AuthPermission)
+        perm = Category.objects.get_permission('read')
+        self.assertEqual(perm.codename, 'read_category')
+        self.assertEqual(Category.objects.get_permission('read_category').pk, perm.pk)
+        self.assertEqual(
+            Category.objects.get_permission('trusts_tests.read_category').pk, perm.pk
+        )
+
+    def test_grant_and_revoke(self):
+        self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_change), self.content))
+        self.content.grant('change', self.user)
+        reload_test_users(self)
+        self.assertTrue(self.user.has_perm(self.get_perm_code(self.perm_change), self.content))
+        self.content.revoke('change', self.user)
+        reload_test_users(self)
+        self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_change), self.content))
+
+
+class FilterByUserContentPermTest(Issue8FixtureMixin, TestCase):
+    def test_filter_by_user_perm_name_still_discovered(self):
+        # The historical PR renamed this test and dropped discovery. Master
+        # kept the original name; this asserts it is still a real test.
+        from trusts.tests import TrustTest
+        self.assertTrue(callable(TrustTest.test_filter_by_user_perm))
+
+    def test_create_under_trust_requires_named_grant(self):
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_add
+        ).save()
+        reload_test_users(self)
+        trusts = Trust.objects.filter_by_user_content_perm(
+            self.user, Category, 'add_category', exclude_root=True
+        )
+        pks = set(trusts.values_list('pk', flat=True))
+        self.assertIn(self.org.pk, pks)
+        self.assertNotIn(self.org_b.pk, pks)
+        self.assertNotIn(Trust.objects.get_root().pk, pks)
+
+    def test_settlor_shortcut_is_not_a_grant(self):
+        # user is settlor of org but has no add grant.
+        trusts = Trust.objects.filter_by_user_content_perm(
+            self.user, Category, 'add', exclude_root=True
+        )
+        self.assertNotIn(self.org.pk, trusts.values_list('pk', flat=True))
+
+    def test_does_not_query_parent_trust_relations(self):
+        # Grant add on the parent (root) must not list the child org.
+        root = Trust.objects.get_root()
+        TrustUserPermission(
+            trust=root, entity=self.user, permission=self.perm_add
+        ).save()
+        reload_test_users(self)
+        trusts = Trust.objects.filter_by_user_content_perm(
+            self.user, Category, 'add_category', exclude_root=False
+        )
+        self.assertIn(root.pk, trusts.values_list('pk', flat=True))
+        self.assertNotIn(self.org.pk, trusts.values_list('pk', flat=True))
+
+    def test_inactive_user_empty(self):
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_add
+        ).save()
+        self.user.is_active = False
+        self.user.save()
+        reload_test_users(self)
+        self.assertFalse(
+            Trust.objects.filter_by_user_content_perm(
+                self.user, Category, 'add'
+            ).exists()
+        )
+
+    def test_role_path_included(self):
+        call_command('update_roles_permissions')
+        admin_role = Role.objects.get(name='admin')
+        self.group.user_set.add(self.user)
+        self.org.groups.add(self.group)
+        admin_role.groups.add(self.group)
+        reload_test_users(self)
+        trusts = Trust.objects.filter_by_user_content_perm(
+            self.user, Category, 'add_category'
+        )
+        self.assertIn(self.org.pk, trusts.values_list('pk', flat=True))
+
+
+class AuthorizationTest(Issue8FixtureMixin, TestCase):
+    def test_reader_cannot_grant_or_mutate(self):
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_read
+        ).save()
+        reload_test_users(self)
+        self.assertFalse(can_administer_content(self.user, self.content))
+        before = TrustUserPermission.objects.filter(trust=self.org).count()
+        with self.assertRaises(AuthorizationDenied):
+            grant_trustee(self.user, self.content, self.user1, 'change')
+        with self.assertRaises(AuthorizationDenied):
+            revoke_trustee(self.user, self.content, self.user, 'read')
+        with self.assertRaises(AuthorizationDenied):
+            associate_group_with_trust(self.user, self.content, self.group)
+        self.assertEqual(TrustUserPermission.objects.filter(trust=self.org).count(), before)
+        self.assertFalse(self.org.groups.filter(pk=self.group.pk).exists())
+
+    def test_change_can_grant_and_revoke(self):
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_change
+        ).save()
+        reload_test_users(self)
+        grant_trustee(self.user, self.content, self.user1, 'read')
+        self.assertTrue(
+            TrustUserPermission.objects.filter(
+                trust=self.org, entity=self.user1, permission=self.perm_read
+            ).exists()
+        )
+        revoke_trustee(self.user, self.content, self.user1, 'read')
+        self.assertFalse(
+            TrustUserPermission.objects.filter(
+                trust=self.org, entity=self.user1, permission=self.perm_read
+            ).exists()
+        )
+
+    def test_membership_alone_cannot_add_team_members(self):
+        self.org.groups.add(self.group)
+        self.user.groups.add(self.group)
+        reload_test_users(self)
+        self.assertFalse(can_manage_group_membership(self.user, self.group))
+        with self.assertRaises(AuthorizationDenied):
+            add_group_member(self.user, self.group, self.user1)
+        self.assertFalse(self.group.user_set.filter(pk=self.user1.pk).exists())
+
+    def test_unknown_entity_id_does_not_mutate(self):
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_change
+        ).save()
+        reload_test_users(self)
+        before = TrustUserPermission.objects.filter(trust=self.org).count()
+        with self.assertRaises(AuthorizationDenied):
+            grant_trustee(self.user, self.content, 99999, 'read')
+        with self.assertRaises(AuthorizationDenied):
+            associate_group_with_trust(self.user, self.content, 99999)
+        self.assertEqual(TrustUserPermission.objects.filter(trust=self.org).count(), before)
+        self.assertEqual(self.org.groups.count(), 0)
+
+    def test_revoke_foreign_trustee_id_is_out_of_scope(self):
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_change
+        ).save()
+        other_tup = TrustUserPermission(
+            trust=self.org_b, entity=self.user1, permission=self.perm_read
+        )
+        other_tup.save()
+        reload_test_users(self)
+        with self.assertRaises(AuthorizationDenied):
+            revoke_trustee(self.user, self.content, self.user1, 'read')
+        self.assertTrue(
+            TrustUserPermission.objects.filter(pk=other_tup.pk).exists()
+        )
+
+    def test_shared_group_permissions_are_not_project_local(self):
+        """Two trusts share a group. Group.permissions must not be written.
+
+        Associating the group with org A (or granting a trustee on A) must
+        not change has_perm on org B. Writing Group.permissions would leak.
+        """
+        shared = Group.objects.create(name='shared-writers')
+        self.org.groups.add(shared)
+        self.org_b.groups.add(shared)
+        shared.user_set.add(self.user1)
+
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_change
+        ).save()
+        reload_test_users(self)
+
+        associate_group_with_trust(self.user, self.content, shared)
+        self.assertFalse(self.user1.has_perm(self.get_perm_code(self.perm_change), self.content))
+        self.assertFalse(self.user1.has_perm(self.get_perm_code(self.perm_change), self.content_b))
+
+        with self.assertRaises(AuthorizationDenied):
+            refuse_group_permission_write()
+
+        # Demonstrate the leak that the old UI would have caused:
+        shared.permissions.add(self.perm_change)
+        reload_test_users(self)
+        self.assertTrue(self.user1.has_perm(self.get_perm_code(self.perm_change), self.content))
+        self.assertTrue(self.user1.has_perm(self.get_perm_code(self.perm_change), self.content_b))
+
+    def test_shared_group_membership_requires_admin_on_every_trust(self):
+        shared = Group.objects.create(name='shared-members')
+        self.org.groups.add(shared)
+        self.org_b.groups.add(shared)
+        change_trust = Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Trust),
+            codename='change_trust',
+        )
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=change_trust
+        ).save()
+        reload_test_users(self)
+        self.assertFalse(can_manage_group_membership(self.user, shared))
+        with self.assertRaises(AuthorizationDenied):
+            add_group_member(self.user, shared, self.user1)
+        self.assertFalse(shared.user_set.filter(pk=self.user1.pk).exists())
+
+        TrustUserPermission(
+            trust=self.org_b, entity=self.user, permission=change_trust
+        ).save()
+        reload_test_users(self)
+        add_group_member(self.user, shared, self.user1)
+        self.assertTrue(shared.user_set.filter(pk=self.user1.pk).exists())
+
+    def test_create_team_requires_trust_admin(self):
+        with self.assertRaises(AuthorizationDenied):
+            create_team(self.user, self.org, 'No Admin Team')
+        self.assertFalse(Group.objects.filter(name='No Admin Team').exists())
+
+        change_trust = Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Trust),
+            codename='change_trust',
+        )
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=change_trust
+        ).save()
+        reload_test_users(self)
+        group = create_team(self.user, self.org, 'Admin Team')
+        self.assertTrue(self.org.groups.filter(pk=group.pk).exists())
+        self.assertTrue(group.user_set.filter(pk=self.user.pk).exists())
+
+    def test_disassociate_rejects_group_not_on_trust(self):
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_change
+        ).save()
+        other = Group.objects.create(name='other-team')
+        self.org_b.groups.add(other)
+        reload_test_users(self)
+        with self.assertRaises(AuthorizationDenied):
+            disassociate_group_from_trust(self.user, self.content, other)
+        self.assertTrue(self.org_b.groups.filter(pk=other.pk).exists())
+
+
+class TeamViewAuthorizationTest(Issue8FixtureMixin, TestCase):
+    def setUp(self):
+        super(TeamViewAuthorizationTest, self).setUp()
+        self.client = Client()
+        self.client.force_login(self.user)
+        self.group = Group.objects.create(name='View Team')
+        self.org.groups.add(self.group)
+        self.user.groups.add(self.group)
+
+    def test_member_get_and_post_denied(self):
+        url = '/teams/%s/' % self.group.pk
+        self.assertEqual(self.client.get(url).status_code, 403)
+        r = self.client.post(url, {'user': self.user1.pk})
+        self.assertEqual(r.status_code, 403)
+        self.assertFalse(self.group.user_set.filter(pk=self.user1.pk).exists())
+
+    def test_admin_can_add_member(self):
+        change_trust = Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Trust),
+            codename='change_trust',
+        )
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=change_trust
+        ).save()
+        reload_test_users(self)
+        self.client.force_login(self.user)
+        url = '/teams/%s/' % self.group.pk
+        self.assertEqual(self.client.get(url).status_code, 200)
+        r = self.client.post(url, {'user': self.user1.pk})
+        self.assertEqual(r.status_code, 302)
+        self.assertTrue(self.group.user_set.filter(pk=self.user1.pk).exists())
+
+    def test_post_unknown_user_does_not_mutate(self):
+        change_trust = Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Trust),
+            codename='change_trust',
+        )
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=change_trust
+        ).save()
+        reload_test_users(self)
+        self.client.force_login(self.user)
+        members_before = set(self.group.user_set.values_list('pk', flat=True))
+        r = self.client.post('/teams/%s/' % self.group.pk, {'user': 99999})
+        self.assertNotEqual(r.status_code, 302)
+        self.assertEqual(
+            set(self.group.user_set.values_list('pk', flat=True)), members_before
+        )
+
+
+class AutoModelAdminTest(TestCase):
+    def test_opt_in_content_and_junction_registered(self):
+        register_auto_modeladmins(admin.site)
+        self.assertTrue(admin.site.is_registered(AutoAdminCategory))
+        self.assertTrue(admin.site.is_registered(AutoAdminJunction))
+        self.assertFalse(admin.site.is_registered(ManualAdminCategory))
+        self.assertFalse(admin.site.is_registered(Category))
+        # Core models remain explicitly registered, not via the flag.
+        self.assertTrue(admin.site.is_registered(Trust))

--- a/trusts/urls.py
+++ b/trusts/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from trusts import views
+
+app_name = 'trusts'
+
+urlpatterns = [
+    path('teams/new/', views.newteam, name='team_create'),
+    path('teams/<int:pk>/', views.team, name='team_detail'),
+]

--- a/trusts/views.py
+++ b/trusts/views.py
@@ -1,0 +1,125 @@
+"""Team management views.
+
+These recover the historical People / create-team pages from #9 with the
+authorization holes closed. ``read`` or mere membership cannot add members.
+Submitted user IDs are resolved through ``authorization`` (unknown IDs do
+not mutate). Creating a team requires ``change`` on a specified trust.
+
+The issue #8 screenshots are not in the current issue body. Templates
+match the historical group_detail / group_form evidence. A separate
+"Team's Team" chrome page and project-settings UI live in the example
+app and are not invented here.
+"""
+
+from django import forms
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseForbidden
+from django.shortcuts import redirect
+from django.views.generic import CreateView, DetailView
+
+from trusts import get_entity_model, get_group_model
+from trusts.authorization import (
+    AuthorizationDenied,
+    add_group_member,
+    can_administer_trust,
+    can_manage_group_membership,
+    create_team,
+)
+from trusts.models import Trust
+
+
+def _entity_queryset():
+    Entity = get_entity_model()
+    qs = Entity._default_manager.all()
+    if hasattr(Entity, 'is_active'):
+        qs = qs.filter(is_active=True)
+    return qs
+
+
+class SelectUserForm(forms.Form):
+    user = forms.ModelChoiceField(queryset=_entity_queryset())
+
+
+class NewTeamForm(forms.ModelForm):
+    trust = forms.ModelChoiceField(queryset=Trust.objects.none())
+
+    class Meta:
+        model = get_group_model()
+        fields = ('name',)
+
+    def __init__(self, user=None, *args, **kwargs):
+        super(NewTeamForm, self).__init__(*args, **kwargs)
+        self.user = user
+        if user is not None:
+            self.fields['trust'].queryset = Trust.objects.filter_by_user_content_perm(
+                user, Trust, 'change', exclude_root=True
+            )
+
+
+class NewTeamView(CreateView):
+    """Create a team attached to a trust the actor administers."""
+    form_class = NewTeamForm
+    template_name = 'auth/group_form.html'
+    model = get_group_model()
+
+    def get_form_kwargs(self):
+        kwargs = super(NewTeamView, self).get_form_kwargs()
+        kwargs['user'] = self.request.user
+        return kwargs
+
+    def get_success_url(self):
+        return '/teams/%s/' % self.object.pk
+
+    def form_valid(self, form):
+        trust = form.cleaned_data['trust']
+        try:
+            self.object = create_team(self.request.user, trust, form.cleaned_data['name'])
+        except AuthorizationDenied:
+            return HttpResponseForbidden()
+        return redirect(self.get_success_url())
+
+
+newteam = login_required(NewTeamView.as_view())
+
+
+class TeamView(DetailView):
+    """Team People page: view members; add only with administrative change."""
+    model = get_group_model()
+    template_name = 'auth/group_detail.html'
+
+    def get_context_data(self, **kwargs):
+        ctx = super(TeamView, self).get_context_data(**kwargs)
+        ctx['adduserform'] = self.adduserform
+        ctx['can_manage_members'] = can_manage_group_membership(
+            self.request.user, self.object
+        )
+        return ctx
+
+    def dispatch(self, request, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.adduserform = SelectUserForm(request.POST or None)
+        group = self.get_object()
+        # Management page: membership or read-only group access is not enough
+        # to open the editor. Any associated trust the user administers, or
+        # full membership-management authority, is required to GET.
+        administers_any = any(
+            can_administer_trust(request.user, trust)
+            for trust in Trust.objects.filter(groups=group)
+        )
+        if not administers_any and not can_manage_group_membership(request.user, group):
+            return HttpResponseForbidden()
+
+        if request.method == 'POST':
+            if not can_manage_group_membership(request.user, group):
+                return HttpResponseForbidden()
+            if self.adduserform.is_valid():
+                try:
+                    add_group_member(request.user, group, self.adduserform.cleaned_data['user'])
+                except AuthorizationDenied:
+                    return HttpResponseForbidden()
+                return redirect('.')
+        return super(TeamView, self).dispatch(request, *args, **kwargs)
+
+
+team = login_required(TeamView.as_view())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Does **not** close https://github.com/django-trusts/django-trusts/issues/8 (partial milestone: core APIs, authorization, `auto_modeladmin`).

@chatforthomas — please re-review. The conditioned-queryset over-grant from https://github.com/django-trusts/django-trusts/pull/20#pullrequestreview-5128030128 is addressed in `73ceda4`.

This is the replacement PR for historical https://github.com/django-trusts/django-trusts/pull/9 (`db80543` on `DJANGO-TRUSTS-8-Edit-Perm-Pages`) and companion https://github.com/django-trusts/django-trusts-example/pull/1. Those branches are not rebased or force-pushed.

Coordinates with example modernization https://github.com/django-trusts/django-trusts-example/pull/2 / https://github.com/django-trusts/django-trusts/issues/16: this PR adds the `permitted` / `grant` / `revoke` APIs that example #2 currently reimplements locally. It does not overwrite example #2.

Salvage map (also posted on #9): https://github.com/django-trusts/django-trusts/pull/9#issuecomment-5563641088

## This PR

- `ContentQuerySet.permitted` includes trustee, `Group.permissions`, and **role** grants; SQL-filtered before pagination; empty for inactive principals; list/direct parity tests
- **Fail closed on `:condition` suffixes:** `.permitted('app.read_category:own', user)` (and custom conditions) raise `PermissionConditionNotQueryable` instead of stripping the suffix and returning every unconditioned grant. Same rule on `filter_by_user_content_perm`. Conditions remain `has_perm` Python predicates until they are SQL-queryable
- `get_permission` uses `TRUSTS_PERMISSION_MODEL` / `get_permission_model()`
- `Content.grant` / `Content.revoke`
- `Trust.objects.filter_by_user_content_perm(user, content, perm_name, exclude_root=True)` with specified create-under-trust semantics (this Trust row, no parent lookup, no settlor shortcut, `fieldlookup` unused). `filter_by_user_perm` and `test_filter_by_user_perm` are unchanged
- `trusts.authorization`: `change` required to mutate; submitted IDs scoped; denial does not write. Membership/`read` cannot add team members or collaborators
- Never writes `Group.permissions`. Two-trust shared-group test documents the leak the old UI would have caused
- Shared-group membership requires `change` on **every** trust using the group
- Authorized team People / create-team views (historical templates only; issue screenshots are not in the #8 body)
- Opt-in `Meta.auto_modeladmin` for concrete Content/Junction subclasses (milestone two). `AppConfig.ready` loads admin only when `django.contrib.admin` is installed (wheel import without admin must succeed)
- `migrates.md` entries 6–13 (conditioned queryset behavior recorded)
- Package remains `1.0.0.dev0`. No `TrustGroup`, no edit of `0001_initial`, no Travis / 0.11.0

## Deferred (still needed before closing #8)

- Example project-settings UI on current example master / PR #2 (not a rebase of example #1)
- Screenshot-faithful chrome and the unclear “Team’s Team” page
- Heroku / Django 1.8 / Travis (historical; not a porting gate)
- SQL compilation of permission conditions (fail-closed exception is the interim)

## Policy question for Thomas

The current schema cannot express “group G has `change` on trust A and only `read` on trust B” without different groups or a new per-trust group-rights table. `Group.permissions` and `Group.user_set` are global. **Recommendation:** do not add `TrustGroup` / `TrustGroupPermission` in this PR. Please confirm before anyone merges a redesign.

## Tests

`python -m tests.runtests` — 93 tests, 1 expected failure (historical Junction `read_*`). Fresh `migrate` applies only `trusts.0001_initial`. `scripts/verify-legacy-upgrade.py` ok. Wheel import without `django.contrib.admin` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-49d5248c-c207-4797-9150-4b4f5bf6902d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-49d5248c-c207-4797-9150-4b4f5bf6902d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

