### PR TITLE
Recover #8 APIs and authorized team views on modern master

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A ``trust`` is a relationship whereby content access is permitted by the creator
 
 ``django-trusts`` also strives to be a **scalable** solution. Permissions checking is offloaded to the database by design, and the implementation minimizes database hits. Permissions are cached per ``trust`` for the lifecycle of ``request user``. If a project's request lifecycle resolves most checked content to one or few ``trusts``, which should be very typically the case, this design should be a winner in term of performance. Permissions checking is done against an individual content or a ``QuerySet``.
 
-``django-trusts`` supports Django's builtins User models ``has_perm()`` / ``has_perms()`` and does not provides any in-addition.
+``django-trusts`` supports Django's builtins User models ``has_perm()`` / ``has_perms()``. List views can use ``Content.objects.permitted(perm, user)`` (SQL filter; paginate after). Create-under-trust querysets use ``Trust.objects.filter_by_user_content_perm(user, Model, perm_name)``. See [migrates.md](migrates.md).
 
 Read more: http://django-trusts.readthedocs.org/en/latest/
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -17,6 +17,10 @@ boundary):
 - `TrustContentTestMixin.test_organization_isolation_denies_cross_trust_access` (added)
 - `TrustTest.test_own_condition_requires_settlor` (added; `:own` is settlor-only)
 - Role tests that a stronger role on one trust does not leak to another
+- `PermittedQuerySetTest` (role grants, inactive parity, filter-before-pagination)
+- `FilterByUserContentPermTest` (create-under-trust, no settlor shortcut, inactive, root exclude)
+- `TeamViewAuthorizationTest` (member cannot add; trustee `change_trust` can; unauthorized group POST is a no-op)
+- `AutoModelAdminTest` (opt-in Content registration)
 
 These run for `Content` subclasses, `Junction` content, and `Trust` as content
 where the mixin applies.
@@ -39,7 +43,7 @@ joined model. That is historical, not a new denial-widening.
 | Decorator `raise_exception=True` | Most decorator tests use `raise_exception=False`. |
 | `TRUSTS_ENTITY_MODEL` swap | Custom entity model is configurable but untested. |
 | Captured production MySQL/Postgres dump | `scripts/verify-legacy-upgrade.py` upgrades a representative 0.10.3-shaped SQLite DB (`trusts.0001_initial` already recorded, historical table DDL). It is not a customer dump and does not replay Django 1.8 contrib tables. |
-| Admin / i18n surfaces | Registered, not exercised. |
+| Admin / i18n surfaces | Core models stay explicitly registered; `auto_modeladmin` is covered for `Category`. |
 
 Do not treat a gap as license to widen access. New grants need an explicit
 test.

--- a/migrates.md
+++ b/migrates.md
@@ -157,6 +157,93 @@ and not a full Django 1.8→6.1 contrib-schema upgrade. Project models still
 need Django's own 1.8→6.1 path (removed APIs, `on_delete`, middleware,
 auto fields). No intermediate Trusts migration is required.
 
+## #8 recovery API additions (1.0.0.dev0)
+
+These are new helpers recovered from historical PR #9 / example PR #1.
+They do **not** rename or remove `filter_by_user_perm`. `0001_initial` is
+unchanged. No `TrustGroup` through table. Package version stays `1.0.0.dev0`.
+
+### 6. `ContentQuerySet.permitted(perm, user)`
+
+| | |
+| --- | --- |
+| Previous | No list-filter API. Callers iterated objects or used `has_perm` per row. Historical #9 `permitted` omitted role grants and used `Group.permissions` only. |
+| New | `Content` subclasses inherit `objects.permitted(perm, user)`. SQL JOIN on trustee, trust-attached `Group.permissions`, and role grants — the same paths as `TrustModelBackend.get_all_permissions`. Paginate **after** this filter. |
+| Replacement | `Model.objects.permitted('read_thing', user)` or `qs.permitted(...)`. |
+| Affected | List views that need Trusts-aware membership. `:own` predicates are **not** in SQL (still Python-side on `has_perm`). Superuser short-circuit is Django `has_perm` only; `permitted` is grant-backed. |
+| Authorization | Anonymous and `is_active=False` return an empty queryset (parity with Django `has_perm`). |
+
+Migration-bot checklist:
+
+- [ ] Find Python loops that call `has_perm` per row to build a list page.
+- [ ] Replace with `qs.permitted(codename, user)` before slicing / paginating.
+- [ ] Confirm inactive users are excluded from both the list and `has_perm`.
+- [ ] Confirm role-granted rows appear (not only `TrustUserPermission` / `Group.permissions`).
+
+### 7. `Trust.objects.filter_by_user_content_perm(user, content, perm_name, exclude_root=True)`
+
+| | |
+| --- | --- |
+| Previous | Only `filter_by_user_perm(user, **kwargs)` (any trustee row or group membership; no permission name). Historical #9 rename queried parent `trust__*` relations, ignored `fieldlookup`, and treated settlor as a grant. The renamed test was not collected. |
+| New | Additional manager method. Returns trusts where `user` holds `perm_name` for Content subclass `content` via the same grant paths as `permitted` / `has_perm`. Settlor identity is **not** a shortcut. Root is excluded by default. |
+| Replacement | Keep `filter_by_user_perm` for the old “any attachment” query. Use `filter_by_user_content_perm` for create-under-trust (trust dropdown). |
+| Affected | Project/content create forms that need trusts the user may attach new rows to. |
+| Authorization | Inactive / anonymous → empty. Does not grant create rights by being settlor alone. |
+
+Migration-bot checklist:
+
+- [ ] Do not replace existing `filter_by_user_perm` callers unless they meant a named permission.
+- [ ] Create-form trust querysets should call `filter_by_user_content_perm(user, Model, 'add_model')`.
+- [ ] Verify a settlor with no trustee/role/group grant is omitted.
+- [ ] Keep `test_filter_by_user_perm` collected; add/keep `test_filter_by_user_content_perm_*`.
+
+### 8. `Content.get_permission` / `Content.grant`
+
+| | |
+| --- | --- |
+| Previous | No public helpers. Historical #9 hardcoded `django.contrib.auth.models.Permission`. |
+| New | `Model.objects.get_permission(perm)` uses `get_permission_model()` (`TRUSTS_PERMISSION_MODEL`). `content.grant(perm, user)` creates a `TrustUserPermission` on `content.trust`. |
+| Replacement | New API. `perm` is a codename or `app_label.codename` (`:condition` stripped). |
+| Affected | Apps that issued trustee rows by hand. Custom permission models now resolve correctly. |
+| Authorization | Grant writes an explicit trustee row; it does not use `Group.permissions`. |
+
+Migration-bot checklist:
+
+- [ ] Replace hardcoded `Permission.objects.get_by_natural_key` on Content managers with `get_permission` if the project uses `TRUSTS_PERMISSION_MODEL`.
+- [ ] Prefer `content.grant(codename, user)` over assembling `TrustUserPermission` by hand.
+
+### 9. `auto_modeladmin` Meta flag
+
+| | |
+| --- | --- |
+| Previous | Only core models registered in `trusts.admin`. #8 milestone 2 was unspecified in #9. |
+| New | Concrete `Content` / `Junction` subclasses with `class Meta: auto_modeladmin = True` are registered in `AppConfig.ready` when `django.contrib.admin` is installed. |
+| Replacement | Opt-in. Existing explicit `admin.site.register` is left alone (`AlreadyRegistered` avoided). |
+| Affected | Project models that set the flag. `auto_modeladmin` is added to Django `options.DEFAULT_NAMES`. |
+| Authorization | Admin registration only; object-level grants are unchanged. |
+
+Migration-bot checklist:
+
+- [ ] Set `auto_modeladmin = True` on concrete Content/Junction models that should appear in admin.
+- [ ] Do not set it on abstract bases.
+- [ ] Confirm admin is in `INSTALLED_APPS`.
+
+### 10. Team views (`trusts.views.newteam` / `team`)
+
+| | |
+| --- | --- |
+| Previous | Historical #9: any group member could add members. No Trusts manage check. |
+| New | `newteam` creates a Django Group and enrolls the creator (membership ≠ manage). `team` GET requires membership (or manage). POST add-member requires a **trustee** `change_trust` grant on a trust that includes the group. Does not write `Group.permissions`. |
+| Replacement | Same URL ideas (`/teams/new/`, `/teams/<pk>/`); authorization is stricter. |
+| Affected | Callers that assumed membership was enough to add people. Wire URLs explicitly. |
+| Authorization | Reader/member POST is 403 with no membership change. POST to a group the user cannot manage is 403. |
+
+Migration-bot checklist:
+
+- [ ] Include `trusts.views` URLs only if the project wants built-in team pages.
+- [ ] Do not treat group membership as permission-administration.
+- [ ] Do not set `Group.permissions` from a project settings form (global, not per-trust). Use `Trust.groups` + `Role` / trustee rows.
+
 ## Migration-bot summary
 
 - [ ] Locate `ForeignKey` without `on_delete` and `user.is_anonymous()` call sites.

--- a/tests/models.py
+++ b/tests/models.py
@@ -8,6 +8,7 @@ class Category(Content):
     name = models.CharField(max_length=40, null=False, blank=False)
 
     class Meta:
+        auto_modeladmin = True
         default_permissions = ('add', 'read', 'change', 'delete')
         permissions = (
             ('add_topic_to_category', 'Add topic to a category'),

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -36,6 +36,7 @@ TEMPLATES = [
         'OPTIONS': {
             'context_processors': [
                 'django.template.context_processors.request',
+                'django.template.context_processors.csrf',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,1 +1,8 @@
-urlpatterns = []
+from django.urls import path
+
+from trusts import views
+
+urlpatterns = [
+    path('teams/new/', views.newteam, name='trusts_team_create'),
+    path('teams/<int:pk>/', views.team, name='trusts_team_detail'),
+]

--- a/trusts/apps.py
+++ b/trusts/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig as DjangoAppConfig
+from django.apps import apps as django_apps
 
 
 class AppConfig(DjangoAppConfig):
@@ -7,3 +8,29 @@ class AppConfig(DjangoAppConfig):
     label = 'trusts'
     # Preserve the historical AutoField primary keys from 0001_initial.
     default_auto_field = 'django.db.models.AutoField'
+
+    def ready(self):
+        self._register_auto_modeladmins()
+
+    def _register_auto_modeladmins(self):
+        """Opt-in admin registration for concrete Content/Junction subclasses.
+
+        Set ``auto_modeladmin = True`` on the model's Meta. Core Trusts models
+        stay explicitly registered in ``trusts.admin``.
+        """
+        if not django_apps.is_installed('django.contrib.admin'):
+            return
+
+        from django.contrib import admin
+        from trusts.models import Content, Junction
+
+        for model in django_apps.get_models():
+            meta = getattr(model, '_meta', None)
+            if meta is None or getattr(meta, 'abstract', False):
+                continue
+            if not getattr(meta, 'auto_modeladmin', False):
+                continue
+            if not issubclass(model, (Content, Junction)):
+                continue
+            if model not in admin.site._registry:
+                admin.site.register(model)

--- a/trusts/models.py
+++ b/trusts/models.py
@@ -8,11 +8,25 @@ from trusts import ENTITY_MODEL_NAME, PERMISSION_MODEL_NAME, GROUP_MODEL_NAME, \
 
 
 options.DEFAULT_NAMES += ('roles', 'permission_conditions',
-                          'content_roles', 'content_permission_conditions'
+                          'content_roles', 'content_permission_conditions',
+                          'auto_modeladmin',
     )
 
 
-class TrustManager(models.Manager):
+class ContentQuerySet(models.QuerySet):
+    def permitted(self, perm, user):
+        """SQL-filter this Content queryset to Trusts-granted rows. Paginate after this."""
+        from trusts.query import content_permitted
+        return content_permitted(self, perm, user)
+
+
+class ContentManager(models.Manager.from_queryset(ContentQuerySet)):
+    def get_permission(self, perm):
+        from trusts.query import get_model_permission
+        return get_model_permission(self.model, perm)
+
+
+class TrustManager(ContentManager):
     def get_or_create_settlor_default(self, settlor, defaults={}, **kwargs):
         if 'trust' in kwargs:
             raise TypeError('"%s" are invalid keyword arguments' % 'trust')
@@ -63,6 +77,16 @@ class TrustManager(models.Manager):
 
         return self.filter(Q(groups__user=user) | Q(trustees__entity=user), **kwargs)
 
+    def filter_by_user_content_perm(self, user, content, perm_name, exclude_root=True, **kwargs):
+        """Trusts where ``user`` holds ``perm_name`` for Content subclass ``content``.
+
+        Create-under-trust helper. See ``trusts.query.trusts_with_content_perm``.
+        """
+        from trusts.query import trusts_with_content_perm
+        return trusts_with_content_perm(
+            self, user, content, perm_name, exclude_root=exclude_root, **kwargs
+        )
+
 
 class ReadonlyFieldsMixin(object):
     def _readonly_attname(self, field_name):
@@ -99,6 +123,7 @@ class ReadonlyFieldsMixin(object):
 class Content(ReadonlyFieldsMixin, models.Model):
     trust = models.ForeignKey('trusts.Trust', related_name='%(app_label)s_%(class)s_content',
                 default=ROOT_PK, null=False, blank=False, on_delete=models.CASCADE)
+    objects = ContentManager()
     _contents = {}
     _conditions = {}
 
@@ -106,6 +131,13 @@ class Content(ReadonlyFieldsMixin, models.Model):
         abstract = True
         default_permissions = ('add', 'change', 'delete', 'read',)
         permission_conditions = ()
+
+    def grant(self, perm, user):
+        """Create a trustee grant on this object's trust for ``perm``."""
+        permission = type(self)._default_manager.get_permission(perm)
+        return TrustUserPermission.objects.get_or_create(
+            trust=self.trust, entity=user, permission=permission
+        )
 
     @staticmethod
     def register_permission_condition(klass, cond_code, func):

--- a/trusts/query.py
+++ b/trusts/query.py
@@ -1,0 +1,121 @@
+"""SQL grant filters shared by list helpers and team administration.
+
+These Q objects match ``TrustModelBackend.get_all_permissions``:
+trustee rows, Django ``Group.permissions`` on a trust-attached group, and
+role-derived grants. They do not evaluate ``:own`` predicates (those stay
+Python-side on ``has_perm``).
+"""
+
+from django.db.models import Q
+
+from trusts import ROOT_PK, get_permission_model
+
+
+def user_is_permission_principal(user):
+    """Active authenticated users only. Matches Django ``has_perm`` deny for inactive."""
+    if user is None:
+        return False
+    if getattr(user, 'is_anonymous', False):
+        return False
+    if not getattr(user, 'is_authenticated', False):
+        return False
+    if not getattr(user, 'is_active', True):
+        return False
+    return True
+
+
+def permission_codename(model, perm):
+    """Accept ``codename`` or ``app_label.codename``, strip ``:condition``."""
+    if not perm:
+        raise ValueError('perm is required')
+    perm = str(perm)
+    if '.' in perm:
+        perm = perm.split('.', 1)[1]
+    return perm.split(':', 1)[0]
+
+
+def get_model_permission(model, perm):
+    """Resolve a permission using ``TRUSTS_PERMISSION_MODEL``, not a hardcoded class."""
+    permission_model = get_permission_model()
+    codename = permission_codename(model, perm)
+    return permission_model.objects.get_by_natural_key(
+        codename,
+        model._meta.app_label,
+        model._meta.model_name,
+    )
+
+
+def grants_q(user, permission, prefix=''):
+    """Q matching trustee / group.permissions / role grants on a Trust.
+
+    ``prefix`` is ``''`` when filtering ``Trust`` rows, or ``'trust__'`` when
+    filtering Content/Junction rows via their ``trust`` FK.
+    """
+    p = prefix or ''
+    return (
+        Q(**{'%strustees__entity' % p: user, '%strustees__permission' % p: permission}) |
+        Q(**{'%sgroups__user' % p: user, '%sgroups__permissions' % p: permission}) |
+        Q(**{'%sgroups__user' % p: user, '%sgroups__roles__permissions' % p: permission})
+    )
+
+
+def content_permitted(queryset, perm, user):
+    """Filter a Content queryset to rows ``user`` may access via Trusts grants.
+
+    Apply this before pagination. Inactive and anonymous principals get no rows.
+    Superuser short-circuit is Django's ``has_perm`` behavior and is not applied
+    here; list membership is grant-backed only.
+    """
+    if not user_is_permission_principal(user):
+        return queryset.none()
+    permission = get_model_permission(queryset.model, perm)
+    return queryset.filter(grants_q(user, permission, prefix='trust__')).distinct()
+
+
+def trusts_with_content_perm(manager, user, content, perm_name, exclude_root=True, **kwargs):
+    """Trusts under which ``user`` holds ``perm_name`` for ``content``.
+
+    Create-under-trust: the queryset for choosing a trust when creating
+    content of that type. Settlor identity alone is not a grant. Root is
+    excluded by default.
+    """
+    if 'group__user' in kwargs:
+        raise TypeError('"%s" are invalid keyword arguments' % 'group__user')
+    if not user_is_permission_principal(user):
+        return manager.none()
+    from trusts.models import Content
+
+    if not Content.is_content_model(content):
+        return manager.none()
+
+    permission = get_model_permission(content, perm_name)
+    qs = manager.filter(grants_q(user, permission), **kwargs)
+    if exclude_root and ROOT_PK is not None:
+        qs = qs.exclude(pk=ROOT_PK)
+    return qs.distinct()
+
+
+def user_can_view_group(user, group):
+    """Members may view a team. Managers may also view."""
+    if not user_is_permission_principal(user):
+        return False
+    if group.user_set.filter(pk=user.pk).exists():
+        return True
+    return user_can_manage_group(user, group)
+
+
+def user_can_manage_group(user, group):
+    """Adding members requires a trustee ``change_trust`` grant on a trust that includes the group.
+
+    Ordinary group membership or a content-read grant is not enough.
+    """
+    from trusts.models import Trust
+
+    if not user_is_permission_principal(user):
+        return False
+    permission = get_model_permission(Trust, 'change_trust')
+    return Trust.objects.filter(
+        groups=group,
+        trustees__entity=user,
+        trustees__permission=permission,
+    ).exists()

--- a/trusts/templates/auth/group_detail.html
+++ b/trusts/templates/auth/group_detail.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>{{ object }}</h1>
+<h2>Members</h2>
+<div>
+{% for u in object.user_set.all %}
+{{ u }}<br>
+{% endfor %}
+</div>
+{% if can_manage %}
+<form method="post">
+    {% csrf_token %}
+    Add member: {{ adduserform.user }}
+    <input type="submit" value="Add">
+</form>
+{% endif %}
+</body>
+</html>

--- a/trusts/templates/auth/group_form.html
+++ b/trusts/templates/auth/group_form.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Create new team</h1>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <input type="submit" value="Create">
+</form>
+</body>
+</html>

--- a/trusts/test_issue8.py
+++ b/trusts/test_issue8.py
@@ -1,0 +1,225 @@
+"""#8 recovery tests. Discovered by `python -m tests.runtests` (trusts app)."""
+
+from django.contrib import admin
+from django.contrib.auth.models import Group, Permission, User
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
+from django.test import TestCase
+
+from tests.models import Category, TestGroupJunction
+from trusts.models import Role, Trust, TrustUserPermission
+from trusts.query import get_model_permission, user_can_manage_group
+from trusts.tests import ContentModelMixin, reload_test_users
+
+
+class PermittedQuerySetTest(ContentModelMixin, TestCase):
+    def test_get_permission_uses_configured_model(self):
+        permission = Category.objects.get_permission('read_category')
+        expected = Permission.objects.get_by_natural_key(
+            'read_category', Category._meta.app_label, Category._meta.model_name
+        )
+        self.assertEqual(permission.pk, expected.pk)
+        self.assertEqual(
+            get_model_permission(Category, 'trusts_tests.read_category:own').pk,
+            expected.pk,
+        )
+
+    def test_grant_and_permitted_trustee(self):
+        trust = Trust(settlor=self.user, title='owned', trust=Trust.objects.get_root())
+        trust.save()
+        allowed = self.create_content(trust)
+        denied_trust = Trust(settlor=self.user1, title='other', trust=Trust.objects.get_root())
+        denied_trust.save()
+        denied = self.create_content(denied_trust)
+
+        allowed.grant('read_category', self.user)
+        reload_test_users(self)
+
+        qs = Category.objects.permitted('read_category', self.user)
+        self.assertTrue(qs.filter(pk=allowed.pk).exists())
+        self.assertFalse(qs.filter(pk=denied.pk).exists())
+        self.assertTrue(self.user.has_perm(self.get_perm_code(self.perm_read), allowed))
+        self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_read), denied))
+
+    def test_permitted_includes_role_grants(self):
+        call_command('update_roles_permissions')
+        trust = Trust(settlor=self.user, title='role trust', trust=Trust.objects.get_root())
+        trust.save()
+        content = self.create_content(trust)
+        self.group.user_set.add(self.user)
+        trust.groups.add(self.group)
+        Role.objects.get(name='public').groups.add(self.group)
+        reload_test_users(self)
+
+        self.assertTrue(self.user.has_perm(self.get_perm_code(self.perm_read), content))
+        self.assertTrue(Category.objects.permitted('read_category', self.user).filter(pk=content.pk).exists())
+        self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_change), content))
+        self.assertFalse(Category.objects.permitted('change_category', self.user).filter(pk=content.pk).exists())
+
+    def test_permitted_inactive_matches_has_perm(self):
+        trust = Trust(settlor=self.user, title='inactive', trust=Trust.objects.get_root())
+        trust.save()
+        content = self.create_content(trust)
+        content.grant('read_category', self.user)
+        self.user.is_active = False
+        self.user.save()
+        reload_test_users(self)
+
+        self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_read), content))
+        self.assertFalse(Category.objects.permitted('read_category', self.user).filter(pk=content.pk).exists())
+
+    def test_permitted_filters_before_pagination(self):
+        denied_trust = Trust(settlor=self.user1, title='first', trust=Trust.objects.get_root())
+        denied_trust.save()
+        denied = self.create_content(denied_trust)
+        allowed_trust = Trust(settlor=self.user, title='second', trust=Trust.objects.get_root())
+        allowed_trust.save()
+        allowed = self.create_content(allowed_trust)
+        allowed.grant('read_category', self.user)
+        reload_test_users(self)
+
+        first_unfiltered = list(Category.objects.order_by('pk')[:1])
+        self.assertEqual(first_unfiltered[0].pk, denied.pk)
+        page = list(Category.objects.permitted('read_category', self.user).order_by('pk')[:1])
+        self.assertEqual(len(page), 1)
+        self.assertEqual(page[0].pk, allowed.pk)
+
+
+class FilterByUserContentPermTest(ContentModelMixin, TestCase):
+    def test_filter_by_user_content_perm_create_under_trust(self):
+        granted = Trust(settlor=self.user, title='can add', trust=Trust.objects.get_root())
+        granted.save()
+        TrustUserPermission.objects.get_or_create(
+            trust=granted, entity=self.user, permission=self.perm_add
+        )
+        settlor_only = Trust(settlor=self.user, title='settlor only', trust=Trust.objects.get_root())
+        settlor_only.save()
+        other = Trust(settlor=self.user1, title='other org', trust=Trust.objects.get_root())
+        other.save()
+        reload_test_users(self)
+
+        trusts = Trust.objects.filter_by_user_content_perm(
+            self.user, Category, 'add_category'
+        )
+        pks = set(trusts.values_list('pk', flat=True))
+        self.assertIn(granted.pk, pks)
+        self.assertNotIn(settlor_only.pk, pks)
+        self.assertNotIn(other.pk, pks)
+        self.assertNotIn(Trust.objects.get_root().pk, pks)
+
+    def test_filter_by_user_content_perm_inactive(self):
+        granted = Trust(settlor=self.user, title='inactive add', trust=Trust.objects.get_root())
+        granted.save()
+        TrustUserPermission.objects.get_or_create(
+            trust=granted, entity=self.user, permission=self.perm_add
+        )
+        self.user.is_active = False
+        self.user.save()
+        reload_test_users(self)
+        self.assertEqual(
+            Trust.objects.filter_by_user_content_perm(self.user, Category, 'add_category').count(),
+            0,
+        )
+
+    def test_filter_by_user_content_perm_exclude_root(self):
+        root = Trust.objects.get_root()
+        TrustUserPermission.objects.get_or_create(
+            trust=root, entity=self.user, permission=self.perm_add
+        )
+        reload_test_users(self)
+        excluded = Trust.objects.filter_by_user_content_perm(
+            self.user, Category, 'add_category', exclude_root=True
+        )
+        included = Trust.objects.filter_by_user_content_perm(
+            self.user, Category, 'add_category', exclude_root=False
+        )
+        self.assertFalse(excluded.filter(pk=root.pk).exists())
+        self.assertTrue(included.filter(pk=root.pk).exists())
+
+
+class AutoModelAdminTest(TestCase):
+    def test_opt_in_content_registered(self):
+        self.assertIn(Category, admin.site._registry)
+
+    def test_junction_without_flag_not_auto_registered(self):
+        self.assertNotIn(TestGroupJunction, admin.site._registry)
+
+
+class TeamViewAuthorizationTest(ContentModelMixin, TestCase):
+    def setUp(self):
+        super(TeamViewAuthorizationTest, self).setUp()
+        self.team = Group.objects.create(name='Acme')
+        self.other = Group.objects.create(name='Other')
+        self.member = User.objects.create_user('member', 'm@example.com', 'pass')
+        self.member.groups.add(self.team)
+        self.outsider = User.objects.create_user('outsider', 'o@example.com', 'pass')
+        self.trust = Trust(settlor=self.user, title='acme trust', trust=Trust.objects.get_root())
+        self.trust.save()
+        self.trust.groups.add(self.team)
+        change = Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Trust),
+            codename='change_trust',
+        )
+        TrustUserPermission.objects.get_or_create(
+            trust=self.trust, entity=self.user, permission=change
+        )
+
+    def test_newteam_creates_and_enrolls_creator(self):
+        self.assertTrue(self.client.login(username=self.username, password=self.password))
+        response = self.client.post('/teams/new/', {'name': 'Created Team'})
+        team = Group.objects.get(name='Created Team')
+        self.assertEqual(response.status_code, 302)
+        self.assertIn(team, self.user.groups.all())
+        self.assertFalse(user_can_manage_group(self.user, team))
+
+    def test_non_member_cannot_view(self):
+        self.assertTrue(self.client.login(username='outsider', password='pass'))
+        response = self.client.get('/teams/%s/' % self.team.pk)
+        self.assertEqual(response.status_code, 403)
+
+    def test_member_can_view_but_cannot_add(self):
+        recruit = User.objects.create_user('recruit', 'r@example.com', 'pass')
+        self.assertTrue(self.client.login(username='member', password='pass'))
+        response = self.client.get('/teams/%s/' % self.team.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Members')
+        self.assertNotContains(response, 'Add member')
+        posted = self.client.post('/teams/%s/' % self.team.pk, {'user': recruit.pk})
+        self.assertEqual(posted.status_code, 403)
+        self.assertFalse(recruit.groups.filter(pk=self.team.pk).exists())
+
+    def test_trustee_change_can_add_member(self):
+        recruit = User.objects.create_user('hire', 'h@example.com', 'pass')
+        self.user.groups.add(self.team)
+        self.assertTrue(self.client.login(username=self.username, password=self.password))
+        response = self.client.get('/teams/%s/' % self.team.pk)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Add member')
+        posted = self.client.post('/teams/%s/' % self.team.pk, {'user': recruit.pk})
+        self.assertEqual(posted.status_code, 302)
+        self.assertTrue(recruit.groups.filter(pk=self.team.pk).exists())
+
+    def test_post_does_not_mutate_unauthorized_group(self):
+        recruit = User.objects.create_user('nope', 'n@example.com', 'pass')
+        self.assertTrue(self.client.login(username=self.username, password=self.password))
+        posted = self.client.post('/teams/%s/' % self.other.pk, {'user': recruit.pk})
+        self.assertEqual(posted.status_code, 403)
+        self.assertFalse(recruit.groups.filter(pk=self.other.pk).exists())
+
+    def test_shared_group_does_not_write_group_permissions(self):
+        other_trust = Trust(settlor=self.user1, title='shared group other', trust=Trust.objects.get_root())
+        other_trust.save()
+        other_trust.groups.add(self.team)
+        before = list(self.team.permissions.values_list('pk', flat=True))
+        self.user.groups.add(self.team)
+        self.assertTrue(self.client.login(username=self.username, password=self.password))
+        recruit = User.objects.create_user('keep', 'k@example.com', 'pass')
+        self.client.post('/teams/%s/' % self.team.pk, {'user': recruit.pk})
+        self.team.refresh_from_db()
+        self.assertEqual(before, list(self.team.permissions.values_list('pk', flat=True)))
+        content_a = self.create_content(self.trust)
+        content_b = self.create_content(other_trust)
+        content_a.grant('read_category', self.user)
+        reload_test_users(self)
+        self.assertTrue(self.user.has_perm(self.get_perm_code(self.perm_read), content_a))
+        self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_read), content_b))

--- a/trusts/views.py
+++ b/trusts/views.py
@@ -1,0 +1,78 @@
+from django import forms
+from django.contrib.auth.decorators import login_required
+from django.http import HttpResponseForbidden
+from django.shortcuts import redirect
+from django.utils.decorators import method_decorator
+from django.views.generic import CreateView, DetailView
+
+from trusts import get_entity_model, get_group_model
+from trusts.query import user_can_manage_group, user_can_view_group
+
+
+class SelectUserForm(forms.Form):
+    user = forms.ModelChoiceField(queryset=None)
+
+    def __init__(self, *args, **kwargs):
+        super(SelectUserForm, self).__init__(*args, **kwargs)
+        self.fields['user'].queryset = get_entity_model().objects.all()
+
+
+@method_decorator(login_required, name='dispatch')
+class NewTeamView(CreateView):
+    """Create a team (Django Group). Creator becomes a member; membership is not manage."""
+
+    fields = ('name',)
+    template_name = 'auth/group_form.html'
+
+    def get_queryset(self):
+        return get_group_model().objects.all()
+
+    def get_form_class(self):
+        return forms.modelform_factory(get_group_model(), fields=self.fields)
+
+    def get_success_url(self):
+        return '/teams/%s/' % self.object.pk
+
+    def form_valid(self, form):
+        response = super(NewTeamView, self).form_valid(form)
+        self.request.user.groups.add(self.object)
+        return response
+
+
+newteam = NewTeamView.as_view()
+
+
+@method_decorator(login_required, name='dispatch')
+class TeamView(DetailView):
+    """View team members. Adding members requires trustee change_trust on an attached trust."""
+
+    template_name = 'auth/group_detail.html'
+
+    def get_queryset(self):
+        return get_group_model().objects.all()
+
+    def dispatch(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if not user_can_view_group(request.user, self.object):
+            return HttpResponseForbidden()
+        return super(TeamView, self).dispatch(request, *args, **kwargs)
+
+    def get_context_data(self, **kwargs):
+        context = super(TeamView, self).get_context_data(**kwargs)
+        context['adduserform'] = SelectUserForm()
+        context['can_manage'] = user_can_manage_group(self.request.user, self.object)
+        return context
+
+    def post(self, request, *args, **kwargs):
+        if not user_can_manage_group(request.user, self.object):
+            return HttpResponseForbidden()
+        form = SelectUserForm(request.POST)
+        if form.is_valid():
+            form.cleaned_data['user'].groups.add(self.object)
+            return redirect(request.path)
+        context = self.get_context_data()
+        context['adduserform'] = form
+        return self.render_to_response(context)
+
+
+team = TeamView.as_view()


### PR DESCRIPTION
Replacement PR for historical [#9](https://github.com/django-trusts/django-trusts/pull/9) / [#8](https://github.com/django-trusts/django-trusts/issues/8), recovered on current master (`1.0.0.dev0`, Python ≥3.12 / Django 6.1). Historical commits on `DJANGO-TRUSTS-8-Edit-Perm-Pages` are left intact. Companion example work remains [example PR #1](https://github.com/django-trusts/django-trusts-example/pull/1) (source) and [example PR #2](https://github.com/django-trusts/django-trusts-example/pull/2) (#16 modernization — not replaced).

@chatforthomas — salvage map is on #9. This is the first replacement milestone (library APIs + team authorization + `auto_modeladmin`). **Does not close #8** (project permission-settings UI is an example follow-up on top of #2).

## What landed

- `Content.objects.permitted(perm, user)` — SQL JOIN on trustee, trust-attached `Group.permissions`, and **role** grants (same paths as `has_perm`). Paginate after. Inactive/anonymous → empty. Superuser short-circuit is Django `has_perm` only; list is grant-backed.
- `Trust.objects.filter_by_user_content_perm(user, content, perm_name, exclude_root=True)` — create-under-trust. Settlor identity is not a grant. `filter_by_user_perm` is unchanged and still collected.
- `Content.objects.get_permission` uses `TRUSTS_PERMISSION_MODEL`. `content.grant(perm, user)` writes a trustee row.
- Opt-in `Meta.auto_modeladmin = True` for concrete Content/Junction subclasses. Core models stay explicit in `trusts.admin`.
- `trusts.views.newteam` / `team`: membership can view; adding members requires a **trustee** `change_trust` grant on a trust that includes the group. Does not write `Group.permissions`.
- `0001_initial` unchanged. No `TrustGroup`. Version stays `1.0.0.dev0`.
- `migrates.md` records 6–10.

## Not in this PR (flagged / later)

- Project permission-settings pages (example follow-up; use Trusts trustees/roles, require change/admin, not read).
- Per-trust group rights that differ from Role (would be a model redesign; not doing unless Thomas asks).
- No approval or merge of historical #9.

## Tests

Local: 82 collected tests on the pushed tree shape (`test_issue8.py` + existing), expected failure `TrustJunctionTestCase.test_read_permissions_added` unchanged. Fresh migrate and `scripts/verify-legacy-upgrade.py` passed.

#8 and #11 stay open.