### PR TITLE
Fail-closed per-Trust group permission intersection

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ A ``trust`` associates content with a ``settlor`` and grants permissions to spec
 
 .. warning::
 
-   The per-trust permission cache is not automatically invalidated when grants, group membership, or roles change. Reload the user object, or explicitly remove its ``_trust_perm_cache`` attribute, before making further permission checks with the same user instance.
+   The per-trust permission cache is not automatically invalidated when grants, group membership, local TrustGroup permissions, or roles change. Reload the user object, or explicitly remove its ``_trust_perm_cache`` attribute, before making further permission checks with the same user instance.
 
 ``django-trusts`` supports Django's built-in user permission methods, ``has_perm()`` and ``has_perms()``.
 
@@ -168,14 +168,25 @@ Here is an example of how roles can be specified::
                ('accounting', ('read_receipt', 'add_receipt', 'change_receipt', 'ask_question_about_receipt')),
            )
 
-Roles specified in different models with the same role name are merged. Once the database entries are created, users in groups linked to a role inherit the permissions assigned to that role.
+Roles specified in different models with the same role name are merged. Once
+the database entries are created, those role permissions become part of the
+group's **global capability ceiling**. Associating a group with a trust
+(``trust.groups.add``) does not grant access by itself. A group permission
+applies to Trust-controlled content only when the user is a member, a
+``TrustGroup`` row exists, the permission is enabled locally on that
+``TrustGroup``, and the permission is in the group's ceiling
+(``Group.permissions`` or a role assigned to the group).
 
-Add a role to a group instead of adding each permission individually::
+Add a role to a group, associate the group, then enable the local subset::
+
+   from trusts.models import TrustGroup
 
    accountants = Group.objects.get(name='accountants')
    accountants.roles.add(Role.objects.get(name='accounting'))
 
    trust.groups.add(accountants)
+   tg = TrustGroup.objects.get(trust=trust, group=accountants)
+   tg.grant_permission(change_receipt)
    r = Receipt(trust=trust, ...)
    r.save()
 

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -45,11 +45,12 @@ joined model. That is historical, not a new denial-widening.
 
 These must keep passing in addition to the table above:
 
-- `PermittedQuerySetTest` — trustee / group.permissions / role list-direct parity, SQL filter, inactive empty, `get_permission`, grant/revoke, conditioned names raise `PermissionConditionNotQueryable`
+- `PermittedQuerySetTest` — trustee / TrustGroup local/global intersection / role-as-ceiling list-direct parity, SQL filter, inactive empty, `get_permission`, grant/revoke, conditioned names raise `PermissionConditionNotQueryable`
 - `FilterByUserContentPermTest` — create-under-trust, no settlor shortcut, no parent-trust leak, inactive empty, `test_filter_by_user_perm` still discovered, conditioned names raise
-- `AuthorizationTest` — reader/member denial with no mutation, scoped entity IDs, shared-group `Group.permissions` leak demonstration, shared-group membership requires admin on every trust
+- `AuthorizationTest` — reader/member denial with no mutation, scoped entity IDs, shared-group ceiling vs local grants, shared-group membership requires admin on every trust
 - `TeamViewAuthorizationTest` — member GET/POST 403, admin add, unknown user PK does not mutate
 - `AutoModelAdminTest` — Content and Junction proxies with `auto_modeladmin = True` register; opt-out does not
+- `TrustGroupIntersectionTest` — issue #23 acceptance: no TrustGroup / empty local / local-without-ceiling deny; both layers allow; per-trust local subsets; removing either layer revokes; two groups combine without widening; trustee unchanged; role-derived ceiling; inactive/anonymous deny; `has_perm` / `.permitted` / `filter_by_user_content_perm` parity; legacy association grants nothing; grandfather dry-run/apply; later ceiling adds stay local-off; configured group/permission models
 
 Do not treat a gap as license to widen access. New grants need an explicit
 test.

--- a/migrates.md
+++ b/migrates.md
@@ -421,7 +421,7 @@ Migration-bot checklist:
 | New | `Trust.associate_group`, `grant_group_permission`, `revoke_group_permission`, `set_group_permissions`. `TrustGroup.grant_permission` / `revoke_permission` / `set_permissions`. Direct writes outside the ceiling raise `ValidationError` (`save`, `bulk_create`, `.permissions.add`). Actor-gated wrappers: `grant_trust_group_permission`, `revoke_trust_group_permission`, `set_trust_group_permissions`. Optional `permissions=` on `associate_group_with_trust`. |
 | Replacement | Call the Trust/TrustGroup methods or authorization helpers. |
 | Affected | Project settings / team UIs (example app tracks UI separately). |
-| Authorization | Ceiling violations are rejected at write time and still deny at read time if a row is forced in. |
+| Authorization | Ceiling violations are rejected at write time and still deny at read time if a row is forced in. A rejected `grant_group_permission` / `set_group_permissions` / `associate_group_with_trust(..., permissions=...)` does not create a TrustGroup row for a previously unassociated group. |
 
 Migration-bot checklist:
 

--- a/migrates.md
+++ b/migrates.md
@@ -324,6 +324,9 @@ schema. This PR refuses to fake them with `Group.permissions` / shared
 `Group.user_set` writes. A redesign (`TrustGroupPermission` or similar)
 must not merge without an explicit go-ahead.
 
+**Superseded by issue #23** for per-trust group permission *levels*.
+Per-trust group *membership* remains out of scope.
+
 ## Migration-bot summary (issue #8)
 
 - [ ] Adopt `permitted` / `grant` / `revoke` / `filter_by_user_content_perm` instead of #9 copies.
@@ -333,4 +336,178 @@ must not merge without an explicit go-ahead.
 - [ ] Do not add `TrustGroup` or edit `0001_initial`.
 - [ ] Set `auto_modeladmin = True` only where you want automatic admin.
 - [ ] Leave package version at `1.0.0.dev0`.
+
+# Issue #23: fail-closed per-Trust group permission intersection (1.0.0.dev0)
+
+This record covers the `TrustGroup` through model and the four-part AND
+invariant. Version remains **1.0.0.dev0**. `trusts.0001_initial` is not
+edited. Example-project UI is out of scope
+(`django-trusts/django-trusts-example#5`).
+
+## Decision
+
+A group permission applies to Trust-controlled content only when **all**
+of these facts exist:
+
+```
+effective(user, permission, trust, group) =
+    user ∈ group
+    AND TrustGroup(trust, group) exists
+    AND permission ∈ TrustGroup.permissions
+    AND permission ∈ Group.permissions
+```
+
+`Group.permissions` is the global capability **ceiling**. Role assignments
+on a group participate in that ceiling; they are not per-Trust role
+grants. `TrustGroup.permissions` is the locally enabled subset. Missing
+membership, association, local grant, or ceiling permission denies access
+(fail closed). Direct `TrustUserPermission` trustee grants are unchanged.
+
+## No change to these public call sites
+
+- `User.has_perm` / `User.has_perms` signatures via `TrustModelBackend`
+- `trusts.decorators.permission_required`, `P`, `K`, `G`, `O`
+- `Trust.objects.get_or_create_settlor_default`, `get_root`,
+  `filter_by_content`, **`filter_by_user_perm`** (membership/trustee, still
+  no permission name)
+- `Content.grant` / `Content.revoke` (still write `TrustUserPermission`)
+- `filter_by_user_content_perm` / `ContentQuerySet.permitted` signatures
+- Package version `1.0.0.dev0`
+
+Authorization **behavior** for group-derived Trust access **does** change
+(see below). Trustee grants and inactive/anonymous denial do not.
+
+## Changes
+
+### 14. `Trust.groups` uses explicit `TrustGroup` through model
+
+| | |
+| --- | --- |
+| Previous (#8) | Implicit M2M. `trust.groups.add(group)` plus `Group.permissions` (or a role on the group) granted that permission on the trust. |
+| New | `through='trusts.TrustGroup'` on the same table (`trusts_trust_groups`). Association rows are preserved. `TrustGroup.permissions` (via `TrustGroupPermission`) is the local grant set and starts empty. |
+| Replacement | `trust.groups.add(group)` still associates. Enable a local subset with `trust.grant_group_permission(group, permission)` or `TrustGroup.grant_permission`. `trusts.authorization.associate_group_with_trust` / `grant_trust_group_permission` wrap those writes with `change`. |
+| Affected | Any caller that treated `Trust.groups.add` as a grant. |
+| Authorization | Association without local tuples grants nothing. |
+
+Migration-bot checklist:
+
+- [ ] Apply `trusts.0002_trustgroup`. Do not edit or fake `0001_initial`.
+- [ ] Confirm every previous `Trust.groups` pair still exists as a `TrustGroup` row.
+- [ ] Confirm `TrustGroup.permissions` is empty after migrate (no inferred policy).
+- [ ] Replace project code that assumed `groups.add` granted access with an explicit local grant.
+- [ ] Do not write `Group.permissions` from a project form (`refuse_group_permission_write`).
+
+### 15. Group-derived `has_perm` / `.permitted()` / `filter_by_user_content_perm`
+
+| | |
+| --- | --- |
+| Previous | SQL and `get_all_permissions` treated `Group.permissions` and role permissions on an associated group as Trust grants. |
+| New | Group-derived access requires the local/global intersection on the **same** `TrustGroup` / group. Two groups union their *effective* rights without mixing one group's local grant with another group's ceiling. Role-derived permissions are ceiling only. Incomplete or inconsistent `TrustGroupPermission` rows deny (read path still requires the ceiling JOIN/Exists). |
+| Replacement | Same APIs. Direct trustee path is unchanged. |
+| Affected | List views, create-under-trust pickers, team/project authorization helpers that use `has_perm` / `trust_grant_q`. |
+| Authorization | Fail closed at every partial state. |
+
+Migration-bot checklist:
+
+- [ ] Re-run allow/deny tests for group members after migrate (expect deny until local tuples exist).
+- [ ] Confirm `has_perm` and `.permitted()` still agree.
+- [ ] Confirm a later add to `Group.permissions` does not enable that permission on existing Trusts until a local grant is created.
+
+### 16. Application API and ceiling enforcement
+
+| | |
+| --- | --- |
+| Previous | `trust.groups.add` / `.remove`. No local grant API. |
+| New | `Trust.associate_group`, `grant_group_permission`, `revoke_group_permission`, `set_group_permissions`. `TrustGroup.grant_permission` / `revoke_permission` / `set_permissions`. Direct writes outside the ceiling raise `ValidationError` (`save`, `bulk_create`, `.permissions.add`). Actor-gated wrappers: `grant_trust_group_permission`, `revoke_trust_group_permission`, `set_trust_group_permissions`. Optional `permissions=` on `associate_group_with_trust`. |
+| Replacement | Call the Trust/TrustGroup methods or authorization helpers. |
+| Affected | Project settings / team UIs (example app tracks UI separately). |
+| Authorization | Ceiling violations are rejected at write time and still deny at read time if a row is forced in. |
+
+Migration-bot checklist:
+
+- [ ] Gate local-grant POSTs on `change`, same as associate/disassociate.
+- [ ] Catch `AuthorizationDenied` / `ValidationError` when a submitted permission is not in the group's ceiling.
+
+### 17. `grandfather_trust_group_permissions` management command
+
+| | |
+| --- | --- |
+| Previous | None. Old implicit access was the default. |
+| New | Operator-controlled copy of each TrustGroup's **current** global ceiling (`Group.permissions` ∪ role permissions) into `TrustGroupPermission`. Default is `--dry-run` (prints exact `trust_id` / `group_id` / `permission_id` tuples, writes nothing). `--apply` inserts. Not run from schema migration. |
+| Replacement | `manage.py grandfather_trust_group_permissions --dry-run` then `--apply` only when a deployment deliberately wants former group-derived access. |
+| Affected | Existing deployments that relied on implicit `Trust.groups` + `Group.permissions`. |
+| Authorization | After `--apply`, former effective group access can be reproduced from the ceiling at apply time. Permissions added to the ceiling later are still not local. |
+
+Migration-bot checklist:
+
+- [ ] Run `--dry-run` and review the tuple list before `--apply`.
+- [ ] Do not invoke this command from `0002` or `post_migrate`.
+- [ ] After `--apply`, confirm a later `Group.permissions.add` still does not grant locally until a new local tuple is created.
+
+## Old vs new behavior
+
+| Situation | Before #23 | After `0002` (no grandfather) | After optional `--apply` |
+| --- | --- | --- | --- |
+| Group member + `Group.permissions` + `Trust.groups` | Allow | Deny (association kept, local empty) | Allow (local copies of then-current ceiling) |
+| `Trust.groups.add` with no `Group.permissions` | Deny | Deny | Deny |
+| Same group, `change` on Trust A and `read` on Trust B | Impossible (global permissions) | Expressible via local grants | Same, if those tuples were in the ceiling at apply |
+| Remove global permission | Revoke everywhere | Revoke everywhere (ceiling) | Same |
+| Remove local permission | N/A | Revoke that Trust only | Same |
+| Add global permission later | Grant on every associated Trust | Ceiling only; local unchanged | Ceiling only; local unchanged |
+| Direct `TrustUserPermission` | Unchanged | Unchanged | Unchanged |
+| Role on a group associated with a Trust | Role perms granted on that Trust | Role perms are ceiling only | Local copies of those ceiling perms if `--apply` |
+| Inactive / anonymous | Deny | Deny | Deny |
+
+## Schema
+
+- Forward migration `trusts.0002_trustgroup` only. **Do not edit `0001_initial`.**
+- `SeparateDatabaseAndState` reuses `trusts_trust_groups` as `TrustGroup` (`unique_together` `(trust, group)`).
+- New table `trusts_trustgrouppermission` for local tuples. Empty after migrate.
+- `TRUSTS_GROUP_MODEL` and `TRUSTS_PERMISSION_MODEL` are respected (same settings as `0001`). Custom group models must keep Django's `auth.Group` query conventions: a `permissions` M2M to the configured permission model and a `user` related-query name for membership. Role.groups already uses `TRUSTS_GROUP_MODEL`. Swapping these settings after tables exist still requires an explicit project migration (same warning as `0001`).
+
+### Fresh database
+
+```
+python -m django migrate --settings=tests.settings
+```
+
+Applies `0001_initial` then `0002_trustgroup` and creates the root trust when
+`TRUSTS_CREATE_ROOT` is true.
+
+### Upgrade of a representative legacy database
+
+`scripts/verify-legacy-upgrade.py` now:
+
+1. Applies Django contrib migrations only.
+2. Creates Trusts tables from `scripts/legacy/trusts_0001_sqlite.sql`.
+3. Records `trusts.0001_initial` as already applied.
+4. Seeds organizations **and** a `Trust.groups` association.
+5. Runs modern `migrate` (applies `0002_trustgroup`, does not re-run `0001`).
+6. Asserts association preserved, local grants empty, group-derived access
+   denied; trustee isolation still holds; grandfather `--dry-run` reports
+   without mutation and `--apply` can restore former group-derived access.
+
+```
+python scripts/verify-legacy-upgrade.py
+```
+
+## Out of scope (unchanged)
+
+- Parent/child Trust inheritance or ceilings
+- Explicit deny / Windows ACL ordering
+- Per-Trust group membership
+- SQL compilation of Python permission conditions
+- Local role assignment on TrustGroup
+- Example-project UI
+
+## Migration-bot summary (issue #23)
+
+- [ ] Apply `trusts.0002_trustgroup`. Do not edit `0001_initial`.
+- [ ] Expect existing `Trust.groups` associations to remain and to grant **nothing** until local tuples exist.
+- [ ] Review `manage.py grandfather_trust_group_permissions --dry-run` if you want former implicit access; `--apply` only with an explicit operator decision.
+- [ ] Stop treating `trust.groups.add` as a grant; use `grant_group_permission` / authorization helpers.
+- [ ] Keep `Group.permissions` and roles as the global ceiling; grant per-Trust subsets on `TrustGroup`.
+- [ ] Reload user objects after grant changes (`_trust_perm_cache`).
+- [ ] Leave package version at `1.0.0.dev0`.
+- [ ] Example UI is a separate issue; do not block this core change on it.
 

--- a/scripts/verify-legacy-upgrade.py
+++ b/scripts/verify-legacy-upgrade.py
@@ -9,7 +9,10 @@ Builds a 0.10.3-shaped database:
    would have).
 4. Seed a root trust plus two organizations with allow/deny grants.
 5. Run modern ``migrate`` without faking or reapplying Trusts 0001.
-6. Smoke-check the root row and organization isolation.
+   Forward ``0002_trustgroup`` converts ``Trust.groups`` to an explicit
+   through model, preserving association rows with empty local grants.
+6. Smoke-check the root row, organization isolation, and fail-closed
+   group-derived access (association preserved, no implicit grant).
 
 This is not a captured production dump and does not replay a full Django
 1.8→6.1 contrib upgrade. It is the Trusts-specific already-applied-0001
@@ -113,13 +116,17 @@ def main() -> int:
             raise SystemExit('Expected only trusts.0001_initial to be recorded after the seed.')
 
         pending_before = _trusts_plan(connection)
-        if pending_before:
-            raise SystemExit('Modern tree wants extra Trusts migrations before upgrade: %s' % pending_before)
+        expected_pending = [('trusts', '0002_trustgroup', False)]
+        if pending_before != expected_pending:
+            raise SystemExit(
+                'Expected pending Trusts migration %s before upgrade, got %s'
+                % (expected_pending, pending_before)
+            )
 
         # 4. Seed organizations after Django can see the historical tables.
-        from django.contrib.auth.models import Permission, User
+        from django.contrib.auth.models import Group, Permission, User
         from django.contrib.contenttypes.models import ContentType
-        from trusts.models import Trust, TrustUserPermission
+        from trusts.models import Trust, TrustGroup, TrustGroupPermission, TrustUserPermission
 
         user_a = User.objects.create_user('org_a_user', 'a@example.com', 'pass')
         user_b = User.objects.create_user('org_b_user', 'b@example.com', 'pass')
@@ -137,9 +144,13 @@ def main() -> int:
         denied_child = Trust(settlor=user_a, title='No Grant Child', trust=denied)
         denied_child.save()
 
+        legacy_group = Group.objects.create(name='legacy-org-a')
+        legacy_group.user_set.add(user_a)
+        org_a.groups.add(legacy_group)
+
         # 5. Modern migrate: must not reapply or fake Trusts 0001.
         call_command('migrate', verbosity=1, interactive=False)
-        if _applied_trusts(connection) != {'0001_initial'}:
+        if _applied_trusts(connection) != {'0001_initial', '0002_trustgroup'}:
             raise SystemExit('Trusts migration set changed during upgrade: %s' % _applied_trusts(connection))
         pending_after = _trusts_plan(connection)
         if pending_after:
@@ -150,6 +161,11 @@ def main() -> int:
             content_type=ContentType.objects.get_for_model(Trust),
             codename='change_trust',
         )
+        read = Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Trust),
+            codename='read_trust',
+        )
+        legacy_group.permissions.add(change, read)
         TrustUserPermission(trust=org_a, entity=user_a, permission=change).save()
         TrustUserPermission(trust=org_b, entity=user_b, permission=change).save()
 
@@ -178,12 +194,48 @@ def main() -> int:
         if user_b.has_perm('trusts.change_trust', denied_child):
             raise SystemExit('Unrelated user was allowed on isolated content.')
 
+        org_a = Trust.objects.get(pk=org_a.pk)
+        if not org_a.groups.filter(pk=legacy_group.pk).exists():
+            raise SystemExit('Legacy Trust.groups association was not preserved.')
+        tg = TrustGroup.objects.get(trust=org_a, group=legacy_group)
+        if tg.permissions.exists():
+            raise SystemExit('Schema migration inferred local TrustGroup permissions.')
+        group_only = User.objects.create_user('group_only', 'g@example.com', 'pass')
+        legacy_group.user_set.add(group_only)
+        group_only = User.objects.get(pk=group_only.pk)
+        child_a = Trust.objects.get(pk=child_a.pk)
+        if group_only.has_perm('trusts.change_trust', child_a):
+            raise SystemExit('Group association granted Trust access without local tuples.')
+        if group_only.has_perm('trusts.read_trust', child_a):
+            raise SystemExit('Group association granted read without local tuples.')
+
+        from io import StringIO
+        dry = StringIO()
+        call_command('grandfather_trust_group_permissions', '--dry-run', stdout=dry)
+        dry_out = dry.getvalue()
+        if 'mode=dry-run' not in dry_out:
+            raise SystemExit('Grandfather dry-run did not report mode=dry-run.')
+        if ('trust_id=%s' % org_a.pk) not in dry_out or ('group_id=%s' % legacy_group.pk) not in dry_out:
+            raise SystemExit('Grandfather dry-run missed the legacy association tuple.')
+        if TrustGroupPermission.objects.filter(trustgroup=tg).exists():
+            raise SystemExit('Grandfather dry-run wrote TrustGroupPermission rows.')
+        group_only = User.objects.get(pk=group_only.pk)
+        if group_only.has_perm('trusts.change_trust', child_a):
+            raise SystemExit('Dry-run mutated authorization.')
+
+        call_command('grandfather_trust_group_permissions', '--apply', stdout=StringIO())
+        group_only = User.objects.get(pk=group_only.pk)
+        child_a = Trust.objects.get(pk=child_a.pk)
+        if not group_only.has_perm('trusts.change_trust', child_a):
+            raise SystemExit('Grandfather --apply did not restore former group-derived access.')
+
         print('legacy upgrade ok')
         print('django', django.get_version())
         print('db', db_path)
         print('applied trusts migrations', sorted(_applied_trusts(connection)))
         print('root', root.pk, root.title)
         print('isolation allow/deny passed')
+        print('trustgroup association preserved; group-derived access fail-closed until grandfather')
     return 0
 
 

--- a/trusts/admin.py
+++ b/trusts/admin.py
@@ -1,12 +1,28 @@
 from django.contrib import admin
 from django.apps import apps as django_apps
 
-from trusts.models import Content, Junction, Trust, Role, RolePermission, TrustUserPermission
+from trusts.models import (
+    Content, Junction, Trust, Role, RolePermission, TrustUserPermission,
+    TrustGroup, TrustGroupPermission,
+)
+
+
+class TrustGroupPermissionInline(admin.TabularInline):
+    model = TrustGroupPermission
+    extra = 0
+
+
+class TrustGroupAdmin(admin.ModelAdmin):
+    list_display = ('id', 'trust', 'group')
+    inlines = (TrustGroupPermissionInline,)
+
 
 admin.site.register(Trust, admin.ModelAdmin)
 admin.site.register(Role, admin.ModelAdmin)
 admin.site.register(RolePermission, admin.ModelAdmin)
 admin.site.register(TrustUserPermission, admin.ModelAdmin)
+admin.site.register(TrustGroup, TrustGroupAdmin)
+admin.site.register(TrustGroupPermission, admin.ModelAdmin)
 
 
 def register_auto_modeladmins(admin_site=None):

--- a/trusts/authorization.py
+++ b/trusts/authorization.py
@@ -164,12 +164,13 @@ def associate_group_with_trust(actor, content, group, permissions=None):
 
     Optional ``permissions`` are local TrustGroup grants and must be a
     subset of the group's global ceiling. Omitting them associates the
-    group without granting anything.
+    group without granting anything. When ``permissions`` is given, the
+    association is created only if every grant is accepted; a rejected
+    set leaves no TrustGroup row for a previously unassociated group.
     """
     _require(can_administer_content(actor, content),
              'change permission is required to associate a team.')
     group = _resolve_group(group)
-    content.trust.groups.add(group)
     if permissions:
         try:
             content.trust.set_group_permissions(group, [
@@ -177,6 +178,8 @@ def associate_group_with_trust(actor, content, group, permissions=None):
             ])
         except ValidationError as exc:
             raise AuthorizationDenied(str(exc))
+    else:
+        content.trust.groups.add(group)
     return group
 
 

--- a/trusts/authorization.py
+++ b/trusts/authorization.py
@@ -1,21 +1,22 @@
 """Administrative authority for trust-scoped mutations.
 
 Ordinary ``read`` and mere group membership are not enough to mutate
-collaborators, group associations, or team membership. Callers must use
-these helpers (or equivalent ``change`` checks) before writing.
+collaborators, group associations, local TrustGroup grants, or team
+membership. Callers must use these helpers (or equivalent ``change``
+checks) before writing.
 
-``Group.permissions`` is a global Django M2M. Helpers here never write it.
-Associating a group with a trust is ``Trust.groups.add`` only. Genuine
-per-trust group permission *levels* are not expressible with the current
-schema; that redesign is flagged for Thomas and is not implemented here.
+``Group.permissions`` (and role assignments on a group) are the global
+capability ceiling. Per-trust group rights are ``TrustGroup.permissions``,
+a locally enabled subset. Helpers here never write ``Group.permissions``.
+Associating a group without local grants grants nothing.
 
 ``Group.user_set`` is also global. Adding a member to a group that two
-trusts share grants that group's rights in both. Membership changes
-therefore require administrative ``change`` on every trust that uses the
-group.
+trusts share grants that group's *effective* rights in both (still subject
+to each trust's local grants). Membership changes therefore require
+administrative ``change`` on every trust that uses the group.
 """
 
-from django.core.exceptions import PermissionDenied
+from django.core.exceptions import PermissionDenied, ValidationError
 
 from trusts import get_entity_model, get_group_model
 from trusts.query import is_active_principal, trust_grant_q
@@ -47,7 +48,7 @@ def can_administer_content(user, obj):
 
 
 def has_trust_row_perm(user, trust, perm):
-    """Grant on this Trust row (trustee / group.permissions / role).
+    """Grant on this Trust row (trustee or TrustGroup local/global intersection).
 
     This does **not** follow ``Trust.trust`` parent resolution used by
     ``has_perm`` when the object itself is a ``Trust``. Create-under-trust
@@ -144,14 +145,38 @@ def revoke_trustee(actor, content, user, perm=None):
     return user
 
 
-def associate_group_with_trust(actor, content, group):
-    """Attach ``group`` to ``content.trust``. Does not write Group.permissions."""
+def _resolve_group(group, queryset=None):
+    Group = get_group_model()
+    if isinstance(group, Group):
+        return group
+    return resolve_entity_id(Group, group, queryset=queryset)
+
+
+def _resolve_content_perm(content, perm):
+    if perm is None:
+        return None
+    Permission = type(content).objects.get_permission(perm) if isinstance(perm, str) else perm
+    return Permission
+
+
+def associate_group_with_trust(actor, content, group, permissions=None):
+    """Attach ``group`` to ``content.trust``. Does not write Group.permissions.
+
+    Optional ``permissions`` are local TrustGroup grants and must be a
+    subset of the group's global ceiling. Omitting them associates the
+    group without granting anything.
+    """
     _require(can_administer_content(actor, content),
              'change permission is required to associate a team.')
-    Group = get_group_model()
-    if not isinstance(group, Group):
-        group = resolve_entity_id(Group, group)
+    group = _resolve_group(group)
     content.trust.groups.add(group)
+    if permissions:
+        try:
+            content.trust.set_group_permissions(group, [
+                _resolve_content_perm(content, perm) for perm in permissions
+            ])
+        except ValidationError as exc:
+            raise AuthorizationDenied(str(exc))
     return group
 
 
@@ -169,13 +194,50 @@ def disassociate_group_from_trust(actor, content, group):
     return group
 
 
+def grant_trust_group_permission(actor, content, group, perm):
+    """Enable a local TrustGroup grant. Requires ``change``; ceiling-enforced."""
+    _require(can_administer_content(actor, content),
+             'change permission is required to grant team permissions.')
+    group = _resolve_group(group)
+    if not content.trust.groups.filter(pk=group.pk).exists():
+        raise AuthorizationDenied('Submitted entity is outside the authorized scope.')
+    permission = _resolve_content_perm(content, perm)
+    try:
+        content.trust.grant_group_permission(group, permission)
+    except ValidationError as exc:
+        raise AuthorizationDenied(str(exc))
+    return group
+
+
+def revoke_trust_group_permission(actor, content, group, perm):
+    """Remove a local TrustGroup grant. Requires ``change``."""
+    _require(can_administer_content(actor, content),
+             'change permission is required to revoke team permissions.')
+    group = _resolve_group(group, queryset=content.trust.groups.all())
+    permission = _resolve_content_perm(content, perm)
+    content.trust.revoke_group_permission(group, permission)
+    return group
+
+
+def set_trust_group_permissions(actor, content, group, permissions):
+    """Replace local TrustGroup grants. Requires ``change``; ceiling-enforced."""
+    _require(can_administer_content(actor, content),
+             'change permission is required to set team permissions.')
+    group = _resolve_group(group, queryset=content.trust.groups.all())
+    resolved = [_resolve_content_perm(content, perm) for perm in permissions]
+    try:
+        content.trust.set_group_permissions(group, resolved)
+    except ValidationError as exc:
+        raise AuthorizationDenied(str(exc))
+    return group
+
+
 def refuse_group_permission_write():
-    """Group.permissions is global; never treat it as project-local."""
+    """Group.permissions is the global ceiling; never treat it as project-local."""
     raise AuthorizationDenied(
-        'Group.permissions is a global Django relation, not a per-trust '
-        'setting. Associate the group with the trust (Trust.groups) and '
-        'use Role permissions or TrustUserPermission. Genuine per-trust '
-        'group rights need a model redesign and are not implemented.'
+        'Group.permissions is a global Django relation (the capability '
+        'ceiling), not a per-trust setting. Associate the group with the '
+        'trust and grant a local subset on TrustGroup.permissions.'
     )
 
 
@@ -217,7 +279,10 @@ def remove_group_member(actor, group, user, via_content=None):
 
 
 def create_team(actor, trust, name, via_content=None):
-    """Create a Group, attach it to ``trust``, and add ``actor`` as a member."""
+    """Create a Group, attach it to ``trust``, and add ``actor`` as a member.
+
+    The new association has an empty local grant set (fail closed).
+    """
     _require(
         can_administer_trust(actor, trust, via_content=via_content),
         'change permission is required to create a team on this trust.',
@@ -243,10 +308,13 @@ __all__ = [
     'create_team',
     'disassociate_group_from_trust',
     'grant_trustee',
+    'grant_trust_group_permission',
     'has_trust_row_perm',
     'refuse_group_permission_write',
     'remove_group_member',
     'resolve_entity_id',
     'revoke_trustee',
+    'revoke_trust_group_permission',
+    'set_trust_group_permissions',
     'trusts_using_group',
 ]

--- a/trusts/backends.py
+++ b/trusts/backends.py
@@ -2,6 +2,7 @@ from django.db.models import Q, QuerySet
 from django.contrib.auth.backends import ModelBackend
 
 from trusts.models import Trust, Content
+from trusts.query import permission_granted_via_group_exists
 from trusts import get_permission_model, utils
 
 
@@ -46,8 +47,12 @@ class TrustModelBackendMixin(object):
             return super(TrustModelBackendMixin, self).get_group_permissions(user_obj, obj)
 
         if Content.is_content(obj):
-            filter = self.perm_model.objects.filter
-            return filter(group__trusts__in=self._get_trusts(obj), group__user=user_obj)
+            trusts = self._get_trusts(obj)
+            if not trusts:
+                return self.perm_model.objects.none()
+            return self.perm_model.objects.filter(
+                permission_granted_via_group_exists(user_obj, trusts)
+            )
 
         return []
 
@@ -66,11 +71,9 @@ class TrustModelBackendMixin(object):
                 if trust.pk not in perm_cache.keys():
                     trust_perm = set([self._get_perm_code(p) for p in
                         self.perm_model.objects.filter(
-                            Q(group__trusts=trust, group__user=user_obj) |
-                            Q(roles__groups__trusts=trust, roles__groups__user=user_obj) |
-                            Q(trustentities__trust=trust, trustentities__entity=user_obj)
+                            Q(trustentities__trust=trust, trustentities__entity=user_obj) |
+                            permission_granted_via_group_exists(user_obj, trust)
                         )
-                        .order_by('group__trusts', 'trustentities__entity')
                     ])
 
                     perm_cache[trust.pk] = trust_perm

--- a/trusts/management/commands/grandfather_trust_group_permissions.py
+++ b/trusts/management/commands/grandfather_trust_group_permissions.py
@@ -1,0 +1,97 @@
+"""Populate empty TrustGroup local grants from the current global ceiling.
+
+Schema migration 0002 preserves Trust.groups associations but does not
+infer authorization policy. Operators who deliberately want the former
+implicit group-derived Trust access can run this command.
+
+Default mode is ``--dry-run`` (report tuples, write nothing). Pass
+``--apply`` to insert ``TrustGroupPermission`` rows.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+from trusts.models import TrustGroup, TrustGroupPermission, get_group_global_ceiling
+
+
+def _perm_code(permission):
+    content_type = getattr(permission, 'content_type', None)
+    app_label = getattr(content_type, 'app_label', None)
+    codename = getattr(permission, 'codename', None)
+    if app_label and codename:
+        return '%s.%s' % (app_label, codename)
+    return str(permission)
+
+
+def iter_grandfather_tuples():
+    """Yield (trust, group, permission) for missing local ceiling copies."""
+    for trustgroup in TrustGroup.objects.select_related('trust', 'group').order_by('pk'):
+        ceiling = get_group_global_ceiling(trustgroup.group)
+        existing = set(
+            TrustGroupPermission.objects.filter(
+                trustgroup=trustgroup
+            ).values_list('permission_id', flat=True)
+        )
+        for permission in ceiling.order_by('pk'):
+            if permission.pk in existing:
+                continue
+            yield trustgroup.trust, trustgroup.group, permission
+
+
+def format_tuple(trust, group, permission):
+    return (
+        'trust_id=%s group_id=%s permission_id=%s %s (trust=%r group=%r)' % (
+            trust.pk,
+            group.pk,
+            permission.pk,
+            _perm_code(permission),
+            getattr(trust, 'title', trust.pk),
+            getattr(group, 'name', group.pk),
+        )
+    )
+
+
+class Command(BaseCommand):
+    help = (
+        'Copy each TrustGroup\'s current global ceiling into local '
+        'TrustGroupPermission rows. Default is --dry-run (no writes).'
+    )
+
+    def add_arguments(self, parser):
+        mode = parser.add_mutually_exclusive_group()
+        mode.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='Report Trust/group/permission tuples without writing (default).',
+        )
+        mode.add_argument(
+            '--apply',
+            action='store_true',
+            help='Insert the reported TrustGroupPermission rows.',
+        )
+
+    def handle(self, *args, **options):
+        apply = bool(options.get('apply'))
+        dry_run = (not apply) or bool(options.get('dry_run'))
+        if apply and options.get('dry_run'):
+            raise CommandError('Pass only one of --dry-run or --apply.')
+
+        tuples = list(iter_grandfather_tuples())
+        mode_label = 'dry-run' if (dry_run and not apply) else 'apply'
+        self.stdout.write(
+            'grandfather_trust_group_permissions mode=%s tuples=%s' % (
+                mode_label, len(tuples)
+            )
+        )
+        for trust, group, permission in tuples:
+            self.stdout.write(format_tuple(trust, group, permission))
+            if apply:
+                TrustGroupPermission.objects.get_or_create(
+                    trustgroup=TrustGroup.objects.get(trust=trust, group=group),
+                    permission=permission,
+                )
+        if not apply:
+            self.stdout.write(
+                'No rows written. Re-run with --apply to insert these tuples.'
+            )
+        else:
+            self.stdout.write('Inserted %s TrustGroupPermission row(s).' % len(tuples))

--- a/trusts/migrations/0002_trustgroup.py
+++ b/trusts/migrations/0002_trustgroup.py
@@ -1,0 +1,92 @@
+# Forward conversion of Trust.groups to an explicit TrustGroup through model.
+# Existing association rows are reused (same table); local permission tuples
+# start empty. Do not edit 0001_initial.
+
+from django.db import migrations, models
+from trusts import GROUP_MODEL_NAME, PERMISSION_MODEL_NAME
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('trusts', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[],
+            state_operations=[
+                migrations.CreateModel(
+                    name='TrustGroup',
+                    fields=[
+                        ('id', models.AutoField(
+                            auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                        )),
+                        ('group', models.ForeignKey(
+                            on_delete=models.CASCADE,
+                            related_name='trustgroups',
+                            to=GROUP_MODEL_NAME,
+                        )),
+                        ('trust', models.ForeignKey(
+                            on_delete=models.CASCADE,
+                            related_name='trustgroups',
+                            to='trusts.trust',
+                        )),
+                    ],
+                    options={
+                        'db_table': 'trusts_trust_groups',
+                        'unique_together': {('trust', 'group')},
+                    },
+                ),
+                migrations.AlterField(
+                    model_name='trust',
+                    name='groups',
+                    field=models.ManyToManyField(
+                        help_text=(
+                            "Groups associated with this trust. Association "
+                            "alone grants nothing; a permission applies only "
+                            "when it is in both the group's global ceiling "
+                            "and this trust's local TrustGroup grants."
+                        ),
+                        related_name='trusts',
+                        through='trusts.TrustGroup',
+                        to=GROUP_MODEL_NAME,
+                        verbose_name='groups',
+                    ),
+                ),
+            ],
+        ),
+        migrations.CreateModel(
+            name='TrustGroupPermission',
+            fields=[
+                ('id', models.AutoField(
+                    auto_created=True, primary_key=True, serialize=False, verbose_name='ID'
+                )),
+                ('permission', models.ForeignKey(
+                    on_delete=models.CASCADE,
+                    related_name='trustgrouppermissions',
+                    to=PERMISSION_MODEL_NAME,
+                )),
+                ('trustgroup', models.ForeignKey(
+                    on_delete=models.CASCADE,
+                    related_name='trustgrouppermissions',
+                    to='trusts.trustgroup',
+                )),
+            ],
+        ),
+        migrations.AlterUniqueTogether(
+            name='trustgrouppermission',
+            unique_together={('trustgroup', 'permission')},
+        ),
+        migrations.AddField(
+            model_name='trustgroup',
+            name='permissions',
+            field=models.ManyToManyField(
+                blank=True,
+                related_name='granted_trustgroups',
+                through='trusts.TrustGroupPermission',
+                to=PERMISSION_MODEL_NAME,
+                verbose_name='permissions',
+            ),
+        ),
+    ]

--- a/trusts/models.py
+++ b/trusts/models.py
@@ -347,12 +347,16 @@ class Trust(Content):
         """Create or return the TrustGroup association. Grants nothing."""
         return TrustGroup.objects.associate(self, group)
 
+    @transaction.atomic
     def grant_group_permission(self, group, permission):
         """Enable ``permission`` locally on this trust for ``group``.
 
-        Associates the group if needed. Rejects permissions outside the
-        group's global ceiling (``Group.permissions`` or role-derived).
+        Associates the group only after ``permission`` is accepted as
+        inside the group's global ceiling. A rejected grant does not
+        create a TrustGroup row.
         """
+        permission = _resolve_configured_permission(permission)
+        require_permissions_in_global_ceiling(group, [permission])
         return self.associate_group(group).grant_permission(permission)
 
     def revoke_group_permission(self, group, permission):
@@ -363,13 +367,17 @@ class Trust(Content):
             return 0
         return tg.revoke_permission(permission)
 
+    @transaction.atomic
     def set_group_permissions(self, group, permissions):
         """Replace this trust's local grants for ``group``.
 
-        Associates the group if needed. Every permission must be inside
-        the group's global ceiling.
+        Associates the group only after every permission is accepted as
+        inside the group's global ceiling. A rejected set does not create
+        a TrustGroup row.
         """
-        return self.associate_group(group).set_permissions(permissions)
+        resolved = [_resolve_configured_permission(p) for p in permissions]
+        require_permissions_in_global_ceiling(group, resolved)
+        return self.associate_group(group).set_permissions(resolved)
 
     class Meta:
         unique_together = ('settlor', 'title')
@@ -441,6 +449,22 @@ def permission_in_global_ceiling(group, permission):
     return get_group_global_ceiling(group).filter(pk=permission.pk).exists()
 
 
+def require_permissions_in_global_ceiling(group, permissions):
+    """Raise ``ValidationError`` if any permission is outside the ceiling.
+
+    Call this before creating a TrustGroup so a rejected grant/set cannot
+    leave an empty association behind.
+    """
+    for permission in permissions:
+        if not permission_in_global_ceiling(group, permission):
+            raise ValidationError(
+                'Permission "%s" is outside the global ceiling of group "%s".' % (
+                    permission, group
+                ),
+                code='local_grant_outside_ceiling',
+            )
+
+
 def _resolve_configured_permission(permission):
     Permission = get_permission_model()
     if isinstance(permission, Permission):
@@ -489,13 +513,7 @@ class TrustGroup(models.Model):
     def grant_permission(self, permission):
         """Add a local grant. Rejected when the permission is outside the ceiling."""
         permission = _resolve_configured_permission(permission)
-        if not permission_in_global_ceiling(self.group, permission):
-            raise ValidationError(
-                'Permission "%s" is outside the global ceiling of group "%s".' % (
-                    permission, self.group
-                ),
-                code='local_grant_outside_ceiling',
-            )
+        require_permissions_in_global_ceiling(self.group, [permission])
         obj, _created = TrustGroupPermission.objects.get_or_create(
             trustgroup=self, permission=permission
         )
@@ -512,14 +530,7 @@ class TrustGroup(models.Model):
     def set_permissions(self, permissions):
         """Replace local grants. Every permission must be in the global ceiling."""
         resolved = [_resolve_configured_permission(p) for p in permissions]
-        for permission in resolved:
-            if not permission_in_global_ceiling(self.group, permission):
-                raise ValidationError(
-                    'Permission "%s" is outside the global ceiling of group "%s".' % (
-                        permission, self.group
-                    ),
-                    code='local_grant_outside_ceiling',
-                )
+        require_permissions_in_global_ceiling(self.group, resolved)
         wanted = {p.pk for p in resolved}
         existing = set(self.permissions.values_list('pk', flat=True))
         TrustGroupPermission.objects.filter(

--- a/trusts/models.py
+++ b/trusts/models.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.db.models import signals, Q, options
 from django.utils.translation import gettext_lazy as _
 
@@ -84,12 +84,14 @@ def resolve_content_permission(model, perm):
 
 class ContentQuerySet(models.QuerySet):
     def permitted(self, perm, user):
-        """Content the user may access via trustee, group, or role grants.
+        """Content the user may access via trustee or group local/global grants.
 
         SQL-filtered (paginate the returned QuerySet). Empty for inactive
-        or anonymous principals. Role-derived grants are included so list
-        results match ``has_perm`` on the supported relational paths.
-        Superuser short-circuit is not duplicated (Django ModelBackend).
+        or anonymous principals. Group-derived access requires the
+        TrustGroup local/global intersection; role-derived permissions
+        participate only as the group's global ceiling. List results match
+        ``has_perm`` on the supported relational paths. Superuser
+        short-circuit is not duplicated (Django ModelBackend).
 
         A ``:condition`` suffix raises ``PermissionConditionNotQueryable``.
         Conditions are not SQL-queryable; refusing them avoids over-granting
@@ -170,8 +172,9 @@ class TrustManager(ContentManager):
         Create-under-trust semantics (verified, not inherited from #9):
 
         - A Trust is included when ``user`` has ``perm_name`` for ``content``
-          via trustee, ``Group.permissions``, or role grants **on that Trust
-          row**.
+          via trustee grants or the TrustGroup local/global intersection
+          **on that Trust row**. Role-derived permissions are the global
+          ceiling, not a local assignment.
         - Parent-trust relations (``trust__trustees`` / ``trust__groups``)
           are not queried. ``#9`` did that accidentally.
         - Settlor identity is not a grant. Use ``has_perm(..., :own)`` for
@@ -329,13 +332,44 @@ class Trust(Content):
     settlor = models.ForeignKey(ENTITY_MODEL_NAME, default=DEFAULT_SETTLOR, null=ALLOW_NULL_SETTLOR, blank=False,
                 on_delete=models.CASCADE)
     groups = models.ManyToManyField(GROUP_MODEL_NAME, related_name='trusts',
+                through='trusts.TrustGroup',
                 verbose_name=_('groups'),
-                help_text=_('The groups this trust grants permissions to. A user will'
-                            'get all permissions granted to each of his/her group.'),
+                help_text=_('Groups associated with this trust. Association '
+                            'alone grants nothing; a permission applies only '
+                            'when it is in both the group\'s global ceiling '
+                            'and this trust\'s local TrustGroup grants.'),
     )
     _readonly_fields = ('trust', 'settlor',)
 
     objects = TrustManager()
+
+    def associate_group(self, group):
+        """Create or return the TrustGroup association. Grants nothing."""
+        return TrustGroup.objects.associate(self, group)
+
+    def grant_group_permission(self, group, permission):
+        """Enable ``permission`` locally on this trust for ``group``.
+
+        Associates the group if needed. Rejects permissions outside the
+        group's global ceiling (``Group.permissions`` or role-derived).
+        """
+        return self.associate_group(group).grant_permission(permission)
+
+    def revoke_group_permission(self, group, permission):
+        """Remove a local TrustGroup grant. Association is left in place."""
+        try:
+            tg = TrustGroup.objects.get(trust=self, group=group)
+        except TrustGroup.DoesNotExist:
+            return 0
+        return tg.revoke_permission(permission)
+
+    def set_group_permissions(self, group, permissions):
+        """Replace this trust's local grants for ``group``.
+
+        Associates the group if needed. Every permission must be inside
+        the group's global ceiling.
+        """
+        return self.associate_group(group).set_permissions(permissions)
 
     class Meta:
         unique_together = ('settlor', 'title')
@@ -385,6 +419,162 @@ class TrustUserPermission(models.Model):
 
     class Meta:
         unique_together = ('trust', 'entity', 'permission')
+
+
+def get_group_global_ceiling(group):
+    """Permissions the group may exercise anywhere: Group.permissions ∪ roles.
+
+    Role assignments are global ceiling only. They are not per-Trust grants.
+    Custom group models must expose a ``permissions`` M2M to
+    ``TRUSTS_PERMISSION_MODEL`` and a ``user`` related-query name for
+    membership (the same conventions as ``auth.Group``).
+    """
+    Permission = get_permission_model()
+    return Permission.objects.filter(
+        Q(group=group) | Q(roles__groups=group)
+    ).distinct()
+
+
+def permission_in_global_ceiling(group, permission):
+    if group is None or permission is None:
+        return False
+    return get_group_global_ceiling(group).filter(pk=permission.pk).exists()
+
+
+def _resolve_configured_permission(permission):
+    Permission = get_permission_model()
+    if isinstance(permission, Permission):
+        return permission
+    if isinstance(permission, int) or getattr(permission, 'pk', None) is not None \
+            and not isinstance(permission, (str, bytes)):
+        try:
+            return Permission.objects.get(pk=getattr(permission, 'pk', permission))
+        except (Permission.DoesNotExist, TypeError, ValueError):
+            pass
+    raise ValidationError(
+        'Local TrustGroup grants require a %s instance.' % Permission.__name__
+    )
+
+
+class TrustGroupManager(models.Manager):
+    def associate(self, trust, group):
+        obj, _created = self.get_or_create(trust=trust, group=group)
+        return obj
+
+
+class TrustGroup(models.Model):
+    """Through model for ``Trust.groups`` plus per-trust local grants.
+
+    Association without local permissions grants nothing. Effective access
+    still requires group membership and the group's global ceiling.
+    """
+    trust = models.ForeignKey('trusts.Trust', related_name='trustgroups', null=False, blank=False,
+                on_delete=models.CASCADE)
+    group = models.ForeignKey(GROUP_MODEL_NAME, related_name='trustgroups', null=False, blank=False,
+                on_delete=models.CASCADE)
+    permissions = models.ManyToManyField(PERMISSION_MODEL_NAME,
+                through='trusts.TrustGroupPermission',
+                related_name='granted_trustgroups', blank=True,
+                verbose_name=_('permissions'))
+
+    objects = TrustGroupManager()
+
+    class Meta:
+        db_table = 'trusts_trust_groups'
+        unique_together = ('trust', 'group')
+
+    def __str__(self):
+        return 'TrustGroup[%s]: trust=%s group=%s' % (self.pk, self.trust_id, self.group_id)
+
+    def grant_permission(self, permission):
+        """Add a local grant. Rejected when the permission is outside the ceiling."""
+        permission = _resolve_configured_permission(permission)
+        if not permission_in_global_ceiling(self.group, permission):
+            raise ValidationError(
+                'Permission "%s" is outside the global ceiling of group "%s".' % (
+                    permission, self.group
+                ),
+                code='local_grant_outside_ceiling',
+            )
+        obj, _created = TrustGroupPermission.objects.get_or_create(
+            trustgroup=self, permission=permission
+        )
+        return obj
+
+    def revoke_permission(self, permission):
+        permission = _resolve_configured_permission(permission)
+        deleted, _ = TrustGroupPermission.objects.filter(
+            trustgroup=self, permission=permission
+        ).delete()
+        return deleted
+
+    @transaction.atomic
+    def set_permissions(self, permissions):
+        """Replace local grants. Every permission must be in the global ceiling."""
+        resolved = [_resolve_configured_permission(p) for p in permissions]
+        for permission in resolved:
+            if not permission_in_global_ceiling(self.group, permission):
+                raise ValidationError(
+                    'Permission "%s" is outside the global ceiling of group "%s".' % (
+                        permission, self.group
+                    ),
+                    code='local_grant_outside_ceiling',
+                )
+        wanted = {p.pk for p in resolved}
+        existing = set(self.permissions.values_list('pk', flat=True))
+        TrustGroupPermission.objects.filter(
+            trustgroup=self, permission_id__in=(existing - wanted)
+        ).delete()
+        for permission in resolved:
+            if permission.pk not in existing:
+                TrustGroupPermission.objects.create(
+                    trustgroup=self, permission=permission
+                )
+        return list(self.permissions.all())
+
+
+class TrustGroupPermissionQuerySet(models.QuerySet):
+    def bulk_create(self, objs, **kwargs):
+        for obj in objs:
+            obj.full_clean()
+        return super(TrustGroupPermissionQuerySet, self).bulk_create(objs, **kwargs)
+
+
+class TrustGroupPermission(models.Model):
+    """Local permission tuple on a TrustGroup. Must stay inside the ceiling."""
+    trustgroup = models.ForeignKey('trusts.TrustGroup', related_name='trustgrouppermissions',
+                null=False, blank=False, on_delete=models.CASCADE)
+    permission = models.ForeignKey(PERMISSION_MODEL_NAME, related_name='trustgrouppermissions',
+                null=False, blank=False, on_delete=models.CASCADE)
+
+    objects = TrustGroupPermissionQuerySet.as_manager()
+
+    class Meta:
+        unique_together = ('trustgroup', 'permission')
+
+    def __str__(self):
+        return 'TrustGroupPermission[%s]: trustgroup=%s permission=%s' % (
+            self.pk, self.trustgroup_id, self.permission_id
+        )
+
+    def clean(self):
+        super(TrustGroupPermission, self).clean()
+        if not self.trustgroup_id or not self.permission_id:
+            raise ValidationError(
+                'TrustGroupPermission requires trustgroup and permission.',
+                code='incomplete_trustgroup_permission',
+            )
+        if not permission_in_global_ceiling(self.trustgroup.group, self.permission):
+            raise ValidationError(
+                'Permission "%s" is outside the global ceiling of group "%s".' % (
+                    self.permission, self.trustgroup.group
+                ),
+                code='local_grant_outside_ceiling',
+            )
+
+    def save(self, *args, **kwargs):
+        self.full_clean()
+        super(TrustGroupPermission, self).save(*args, **kwargs)
 
 
 class Junction(ReadonlyFieldsMixin, models.Model):

--- a/trusts/query.py
+++ b/trusts/query.py
@@ -1,11 +1,16 @@
 """SQL grant filters shared by list APIs and trust-row checks.
 
-These Q objects JOIN the same trustee / group.permissions / role tables
+These expressions JOIN the same trustee / TrustGroup / ceiling tables
 that ``TrustModelBackend.get_all_permissions`` reads. Callers must apply
 them on a QuerySet (then paginate). They are not Python predicates.
+
+Group-derived access is fail-closed. A group permission matches only when
+the user is a member, a ``TrustGroup`` row exists, the permission is in
+``TrustGroup.permissions``, and the permission is in the group's global
+ceiling (``Group.permissions`` or role-derived). Incomplete rows deny.
 """
 
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 
 
 def is_active_principal(user):
@@ -25,25 +30,67 @@ def is_active_principal(user):
     return True
 
 
+def _trust_lookup(trusts):
+    if trusts is None:
+        return {}
+    if hasattr(trusts, 'pk') and not hasattr(trusts, 'model'):
+        return {'trust': trusts}
+    return {'trust__in': trusts}
+
+
+def group_local_grant_exists(user, permission, trust_id_outerref):
+    """Exists: same TrustGroup, member, local grant, and global ceiling.
+
+    ``trust_id_outerref`` is the outer row's Trust PK column (``pk`` on
+    Trust, ``trust_id`` on Content).
+    """
+    from trusts.models import TrustGroup
+
+    return Exists(
+        TrustGroup.objects.filter(
+            trust_id=OuterRef(trust_id_outerref),
+            group__user=user,
+            permissions=permission,
+        ).filter(
+            Q(group__permissions=permission) |
+            Q(group__roles__permissions=permission)
+        )
+    )
+
+
+def permission_granted_via_group_exists(user, trusts):
+    """Exists against an outer Permission queryset for ``user`` on ``trusts``.
+
+    ``trusts`` is a Trust instance, queryset, or id list. Empty ``trust__in``
+    matches nothing.
+    """
+    from trusts.models import TrustGroup
+
+    return Exists(
+        TrustGroup.objects.filter(
+            group__user=user,
+            permissions=OuterRef('pk'),
+            **_trust_lookup(trusts)
+        ).filter(
+            Q(group__permissions=OuterRef('pk')) |
+            Q(group__roles__permissions=OuterRef('pk'))
+        )
+    )
+
+
 def trust_grant_q(user, permission, trust_fk=''):
-    """Return a Q matching trustee, group.permissions, and role-derived grants.
+    """Return a Q matching trustee grants or the group local/global intersection.
 
     ``trust_fk`` is the lookup prefix to the Trust row:
     - ``''`` filters ``Trust`` rows themselves (create-under-trust).
     - ``'trust'`` filters Content rows via ``Content.trust``.
     """
     prefix = ('%s__' % trust_fk) if trust_fk else ''
+    trust_id_ref = 'pk' if not trust_fk else '%s_id' % trust_fk
     return (
         Q(**{
             '%strustees__entity' % prefix: user,
             '%strustees__permission' % prefix: permission,
         }) |
-        Q(**{
-            '%sgroups__user' % prefix: user,
-            '%sgroups__permissions' % prefix: permission,
-        }) |
-        Q(**{
-            '%sgroups__user' % prefix: user,
-            '%sgroups__roles__permissions' % prefix: permission,
-        })
+        group_local_grant_exists(user, permission, trust_id_ref)
     )

--- a/trusts/test_issue23.py
+++ b/trusts/test_issue23.py
@@ -293,11 +293,57 @@ class TrustGroupIntersectionTest(Issue8FixtureMixin, TestCase):
             get_permission_model(),
         )
 
-    def test_application_api_rejects_outside_ceiling_and_authorization_wraps(self):
-        extra = Permission.objects.get(
+    def _outside_ceiling_perm(self):
+        return Permission.objects.get(
             content_type=ContentType.objects.get_for_model(Category),
             codename='delete_category',
         )
+
+    def _assert_unassociated(self, group=None):
+        group = group if group is not None else self.group
+        self.assertFalse(TrustGroup.objects.filter(trust=self.org, group=group).exists())
+        self.assertFalse(self.org.groups.filter(pk=group.pk).exists())
+
+    def test_rejected_grant_does_not_create_association(self):
+        extra = self._outside_ceiling_perm()
+        self._assert_unassociated()
+        with self.assertRaises(ValidationError):
+            self.org.grant_group_permission(self.group, extra)
+        self._assert_unassociated()
+
+    def test_rejected_set_permissions_does_not_create_association(self):
+        extra = self._outside_ceiling_perm()
+        self._assert_unassociated()
+        with self.assertRaises(ValidationError):
+            self.org.set_group_permissions(self.group, [self.perm_read, extra])
+        self._assert_unassociated()
+
+    def test_rejected_associate_with_permissions_does_not_create_association(self):
+        extra = self._outside_ceiling_perm()
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_change
+        ).save()
+        reload_test_users(self)
+        self._assert_unassociated()
+        with self.assertRaises(AuthorizationDenied):
+            associate_group_with_trust(
+                self.user, self.content, self.group, permissions=[extra]
+            )
+        self._assert_unassociated()
+
+    def test_rejected_grant_keeps_existing_association(self):
+        extra = self._outside_ceiling_perm()
+        self.org.groups.add(self.group)
+        with self.assertRaises(ValidationError):
+            self.org.grant_group_permission(self.group, extra)
+        self.assertTrue(TrustGroup.objects.filter(trust=self.org, group=self.group).exists())
+        self.assertEqual(
+            TrustGroup.objects.get(trust=self.org, group=self.group).permissions.count(),
+            0,
+        )
+
+    def test_application_api_rejects_outside_ceiling_and_authorization_wraps(self):
+        extra = self._outside_ceiling_perm()
         with self.assertRaises(ValidationError):
             self.org.grant_group_permission(self.group, extra)
         TrustUserPermission(

--- a/trusts/test_issue23.py
+++ b/trusts/test_issue23.py
@@ -1,0 +1,315 @@
+"""Acceptance tests for issue #23: fail-closed per-Trust group intersection."""
+
+from io import StringIO
+
+from django.contrib.auth.models import AnonymousUser, Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import ValidationError
+from django.core.management import call_command
+from django.db import connection
+from django.test import TestCase
+
+from trusts import get_group_model, get_permission_model
+from trusts.authorization import (
+    AuthorizationDenied,
+    associate_group_with_trust,
+    grant_trust_group_permission,
+    grant_trustee,
+)
+from trusts.models import (
+    Role,
+    Trust,
+    TrustGroup,
+    TrustGroupPermission,
+    TrustUserPermission,
+)
+from trusts.test_issue8 import Issue8FixtureMixin
+from trusts.tests import enable_local_group_grant, reload_test_users
+from tests.models import Category
+
+
+class TrustGroupIntersectionTest(Issue8FixtureMixin, TestCase):
+    def setUp(self):
+        super(TrustGroupIntersectionTest, self).setUp()
+        self.user.groups.add(self.group)
+        self.perm_read.group_set.add(self.group)
+        self.perm_change.group_set.add(self.group)
+
+    def _has_read(self, user, obj):
+        return user.has_perm(self.get_perm_code(self.perm_read), obj)
+
+    def _has_change(self, user, obj):
+        return user.has_perm(self.get_perm_code(self.perm_change), obj)
+
+    def test_01_no_trustgroup_denies(self):
+        reload_test_users(self)
+        self.assertFalse(TrustGroup.objects.filter(trust=self.org, group=self.group).exists())
+        self.assertFalse(self._has_read(self.user, self.content))
+        self.assertNotIn(
+            self.content.pk,
+            Category.objects.permitted('read', self.user).values_list('pk', flat=True),
+        )
+
+    def test_02_trustgroup_without_local_denies(self):
+        self.org.groups.add(self.group)
+        reload_test_users(self)
+        self.assertTrue(TrustGroup.objects.filter(trust=self.org, group=self.group).exists())
+        self.assertFalse(
+            TrustGroupPermission.objects.filter(
+                trustgroup__trust=self.org, trustgroup__group=self.group
+            ).exists()
+        )
+        self.assertFalse(self._has_read(self.user, self.content))
+
+    def test_03_local_without_global_ceiling_denies(self):
+        other = Group.objects.create(name='no-ceiling')
+        other.user_set.add(self.user)
+        self.org.groups.add(other)
+        tg = TrustGroup.objects.get(trust=self.org, group=other)
+        with self.assertRaises(ValidationError):
+            tg.grant_permission(self.perm_read)
+        with connection.cursor() as cursor:
+            cursor.execute(
+                'INSERT INTO trusts_trustgrouppermission (trustgroup_id, permission_id) '
+                'VALUES (%s, %s)',
+                [tg.pk, self.perm_read.pk],
+            )
+        reload_test_users(self)
+        self.assertFalse(self._has_read(self.user, self.content))
+        self.assertNotIn(
+            self.content.pk,
+            Category.objects.permitted('read', self.user).values_list('pk', flat=True),
+        )
+
+    def test_03b_permissions_add_outside_ceiling_rejected(self):
+        other = Group.objects.create(name='no-ceiling-add')
+        self.org.groups.add(other)
+        tg = TrustGroup.objects.get(trust=self.org, group=other)
+        with self.assertRaises(ValidationError):
+            tg.permissions.add(self.perm_read)
+
+    def test_04_global_and_local_allows(self):
+        enable_local_group_grant(self.org, self.group, self.perm_read)
+        reload_test_users(self)
+        self.assertTrue(self._has_read(self.user, self.content))
+        self.assertFalse(self._has_change(self.user, self.content))
+
+    def test_05_same_group_different_local_grants_per_trust(self):
+        enable_local_group_grant(self.org, self.group, self.perm_change)
+        enable_local_group_grant(self.org_b, self.group, self.perm_read)
+        reload_test_users(self)
+        self.assertTrue(self._has_change(self.user, self.content))
+        self.assertFalse(self._has_read(self.user, self.content))
+        self.assertTrue(self._has_read(self.user, self.content_b))
+        self.assertFalse(self._has_change(self.user, self.content_b))
+
+    def test_06_removing_either_layer_revokes(self):
+        enable_local_group_grant(self.org, self.group, self.perm_read)
+        reload_test_users(self)
+        self.assertTrue(self._has_read(self.user, self.content))
+
+        self.org.revoke_group_permission(self.group, self.perm_read)
+        reload_test_users(self)
+        self.assertFalse(self._has_read(self.user, self.content))
+
+        enable_local_group_grant(self.org, self.group, self.perm_read)
+        reload_test_users(self)
+        self.assertTrue(self._has_read(self.user, self.content))
+
+        self.group.permissions.remove(self.perm_read)
+        reload_test_users(self)
+        self.assertFalse(self._has_read(self.user, self.content))
+
+    def test_07_two_groups_combine_without_widening(self):
+        g_read = Group.objects.create(name='readers')
+        g_change = Group.objects.create(name='writers')
+        g_read.permissions.add(self.perm_read)
+        g_change.permissions.add(self.perm_change)
+        self.user.groups.add(g_read, g_change)
+        enable_local_group_grant(self.org, g_read, self.perm_read)
+        enable_local_group_grant(self.org, g_change, self.perm_change)
+        reload_test_users(self)
+        self.assertTrue(self._has_read(self.user, self.content))
+        self.assertTrue(self._has_change(self.user, self.content))
+
+        self.user.groups.remove(g_change)
+        reload_test_users(self)
+        self.assertTrue(self._has_read(self.user, self.content))
+        self.assertFalse(self._has_change(self.user, self.content))
+
+        g_read.permissions.add(self.perm_change)
+        reload_test_users(self)
+        # Ceiling widened on readers, but local grant is still read-only.
+        self.assertFalse(self._has_change(self.user, self.content))
+
+        self.user.groups.add(g_change)
+        reload_test_users(self)
+        self.assertTrue(self._has_change(self.user, self.content))
+        self.user.groups.remove(g_change)
+        reload_test_users(self)
+        self.assertFalse(self._has_change(self.user, self.content))
+
+    def test_08_direct_trustee_unchanged(self):
+        TrustUserPermission(
+            trust=self.org, entity=self.user1, permission=self.perm_read
+        ).save()
+        reload_test_users(self)
+        self.assertTrue(self._has_read(self.user1, self.content))
+        self.assertFalse(self._has_read(self.user1, self.content_b))
+        self.assertNotIn(
+            self.user1.pk,
+            Group.objects.filter(pk=self.group.pk).values_list('user', flat=True),
+        )
+
+    def test_09_role_derived_ceiling(self):
+        call_command('update_roles_permissions')
+        role_group = Group.objects.create(name='role-public')
+        role_group.user_set.add(self.user1)
+        Role.objects.get(name='public').groups.add(role_group)
+        self.org.groups.add(role_group)
+        reload_test_users(self)
+        self.assertFalse(self._has_read(self.user1, self.content))
+        enable_local_group_grant(self.org, role_group, self.perm_read)
+        reload_test_users(self)
+        self.assertTrue(self._has_read(self.user1, self.content))
+        self.assertFalse(self._has_change(self.user1, self.content))
+
+    def test_10_inactive_and_anonymous_denied(self):
+        enable_local_group_grant(self.org, self.group, self.perm_read)
+        reload_test_users(self)
+        self.assertTrue(self._has_read(self.user, self.content))
+        self.user.is_active = False
+        self.user.save()
+        reload_test_users(self)
+        self.assertFalse(self._has_read(self.user, self.content))
+        self.assertFalse(Category.objects.permitted('read', self.user).exists())
+        anon = AnonymousUser()
+        self.assertFalse(self._has_read(anon, self.content))
+        self.assertFalse(Category.objects.permitted('read', anon).exists())
+
+    def test_11_has_perm_permitted_parity(self):
+        enable_local_group_grant(self.org, self.group, self.perm_read)
+        TrustUserPermission(
+            trust=self.org_b, entity=self.user, permission=self.perm_read
+        ).save()
+        reload_test_users(self)
+        direct = set(
+            obj.pk for obj in Category.objects.all()
+            if self.user.has_perm(self.get_perm_code(self.perm_read), obj)
+        )
+        listed = set(Category.objects.permitted('read', self.user).values_list('pk', flat=True))
+        self.assertEqual(direct, listed)
+        self.assertEqual(direct, {self.content.pk, self.content_b.pk})
+        sql = str(Category.objects.permitted('read', self.user).query)
+        self.assertTrue(
+            'JOIN' in sql.upper() or 'EXISTS' in sql.upper(),
+            'permitted() must filter in SQL. SQL was: %s' % sql,
+        )
+        trusts = Trust.objects.filter_by_user_content_perm(
+            self.user, Category, 'read', exclude_root=True
+        )
+        self.assertEqual(set(trusts.values_list('pk', flat=True)), {self.org.pk, self.org_b.pk})
+
+    def test_12_legacy_association_preserves_rows_but_grants_nothing(self):
+        self.org.groups.add(self.group)
+        reload_test_users(self)
+        self.assertTrue(self.org.groups.filter(pk=self.group.pk).exists())
+        tg = TrustGroup.objects.get(trust=self.org, group=self.group)
+        self.assertEqual(tg.permissions.count(), 0)
+        self.assertFalse(self._has_read(self.user, self.content))
+        self.assertFalse(self._has_change(self.user, self.content))
+        self.assertFalse(
+            Trust.objects.filter_by_user_content_perm(
+                self.user, Category, 'read', exclude_root=True
+            ).filter(pk=self.org.pk).exists()
+        )
+
+    def test_13_grandfather_dry_run_and_apply(self):
+        self.org.groups.add(self.group)
+        reload_test_users(self)
+        self.assertFalse(self._has_read(self.user, self.content))
+
+        dry = StringIO()
+        call_command('grandfather_trust_group_permissions', '--dry-run', stdout=dry)
+        report = dry.getvalue()
+        self.assertIn('mode=dry-run', report)
+        self.assertIn('trust_id=%s' % self.org.pk, report)
+        self.assertIn('group_id=%s' % self.group.pk, report)
+        self.assertIn('permission_id=%s' % self.perm_read.pk, report)
+        self.assertIn('permission_id=%s' % self.perm_change.pk, report)
+        self.assertFalse(
+            TrustGroupPermission.objects.filter(
+                trustgroup__trust=self.org, trustgroup__group=self.group
+            ).exists()
+        )
+        self.assertFalse(self._has_read(self.user, self.content))
+
+        applied = StringIO()
+        call_command('grandfather_trust_group_permissions', '--apply', stdout=applied)
+        self.assertIn('mode=apply', applied.getvalue())
+        self.assertTrue(
+            TrustGroupPermission.objects.filter(
+                trustgroup__trust=self.org,
+                trustgroup__group=self.group,
+                permission=self.perm_read,
+            ).exists()
+        )
+        reload_test_users(self)
+        self.assertTrue(self._has_read(self.user, self.content))
+        self.assertTrue(self._has_change(self.user, self.content))
+
+        again = StringIO()
+        call_command('grandfather_trust_group_permissions', '--dry-run', stdout=again)
+        self.assertIn('tuples=0', again.getvalue())
+
+    def test_14_later_global_ceiling_is_not_silently_local(self):
+        enable_local_group_grant(self.org, self.group, self.perm_read)
+        extra = Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Category),
+            codename='add_category',
+        )
+        self.group.permissions.add(extra)
+        reload_test_users(self)
+        self.assertTrue(self._has_read(self.user, self.content))
+        self.assertFalse(self.user.has_perm(self.get_perm_code(extra), self.content))
+        self.assertNotIn(
+            extra.pk,
+            TrustGroup.objects.get(trust=self.org, group=self.group).permissions.values_list(
+                'pk', flat=True
+            ),
+        )
+        enable_local_group_grant(self.org, self.group, extra)
+        reload_test_users(self)
+        self.assertTrue(self.user.has_perm(self.get_perm_code(extra), self.content))
+
+    def test_15_configured_group_and_permission_models(self):
+        self.assertIs(TrustGroup._meta.get_field('group').remote_field.model, get_group_model())
+        self.assertIs(
+            TrustGroupPermission._meta.get_field('permission').remote_field.model,
+            get_permission_model(),
+        )
+        self.assertIs(
+            TrustGroup._meta.get_field('permissions').remote_field.model,
+            get_permission_model(),
+        )
+
+    def test_application_api_rejects_outside_ceiling_and_authorization_wraps(self):
+        extra = Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Category),
+            codename='delete_category',
+        )
+        with self.assertRaises(ValidationError):
+            self.org.grant_group_permission(self.group, extra)
+        TrustUserPermission(
+            trust=self.org, entity=self.user, permission=self.perm_change
+        ).save()
+        reload_test_users(self)
+        associate_group_with_trust(self.user, self.content, self.group)
+        with self.assertRaises(AuthorizationDenied):
+            grant_trust_group_permission(self.user, self.content, self.group, extra)
+        grant_trust_group_permission(self.user, self.content, self.group, 'read')
+        reload_test_users(self)
+        self.assertTrue(self._has_read(self.user, self.content))
+        grant_trustee(self.user, self.content, self.user1, 'change')
+        reload_test_users(self)
+        self.assertTrue(self._has_change(self.user1, self.content))

--- a/trusts/test_issue8.py
+++ b/trusts/test_issue8.py
@@ -33,6 +33,7 @@ from trusts.models import (
 from trusts.tests import (
     ContentModelMixin,
     create_test_users,
+    enable_local_group_grant,
     get_or_create_root_user,
     reload_test_users,
 )
@@ -80,7 +81,7 @@ class PermittedQuerySetTest(Issue8FixtureMixin, TestCase):
     def test_group_permissions_path(self):
         self.perm_read.group_set.add(self.group)
         self.user.groups.add(self.group)
-        self.org.groups.add(self.group)
+        enable_local_group_grant(self.org, self.group, self.perm_read)
         reload_test_users(self)
         self._assert_list_direct_parity(self.perm_read, self.user)
 
@@ -89,6 +90,7 @@ class PermittedQuerySetTest(Issue8FixtureMixin, TestCase):
         self.group.user_set.add(self.user)
         self.org.groups.add(self.group)
         Role.objects.get(name='public').groups.add(self.group)
+        enable_local_group_grant(self.org, self.group, self.perm_read)
         reload_test_users(self)
         self.assertTrue(self.user.has_perm(self.get_perm_code(self.perm_read), self.content))
         qs = Category.objects.permitted('read_category', self.user)
@@ -213,6 +215,7 @@ class FilterByUserContentPermTest(Issue8FixtureMixin, TestCase):
         self.group.user_set.add(self.user)
         self.org.groups.add(self.group)
         admin_role.groups.add(self.group)
+        enable_local_group_grant(self.org, self.group, self.perm_add)
         reload_test_users(self)
         trusts = Trust.objects.filter_by_user_content_perm(
             self.user, Category, 'add_category'
@@ -316,10 +319,10 @@ class AuthorizationTest(Issue8FixtureMixin, TestCase):
         )
 
     def test_shared_group_permissions_are_not_project_local(self):
-        """Two trusts share a group. Group.permissions must not be written.
+        """Two trusts share a group. Group.permissions is ceiling, not a grant.
 
-        Associating the group with org A (or granting a trustee on A) must
-        not change has_perm on org B. Writing Group.permissions would leak.
+        Associating the group, or writing Group.permissions, must not grant
+        access until a local TrustGroup permission exists on that trust.
         """
         shared = Group.objects.create(name='shared-writers')
         self.org.groups.add(shared)
@@ -338,11 +341,15 @@ class AuthorizationTest(Issue8FixtureMixin, TestCase):
         with self.assertRaises(AuthorizationDenied):
             refuse_group_permission_write()
 
-        # Demonstrate the leak that the old UI would have caused:
         shared.permissions.add(self.perm_change)
         reload_test_users(self)
+        self.assertFalse(self.user1.has_perm(self.get_perm_code(self.perm_change), self.content))
+        self.assertFalse(self.user1.has_perm(self.get_perm_code(self.perm_change), self.content_b))
+
+        enable_local_group_grant(self.org, shared, self.perm_change)
+        reload_test_users(self)
         self.assertTrue(self.user1.has_perm(self.get_perm_code(self.perm_change), self.content))
-        self.assertTrue(self.user1.has_perm(self.get_perm_code(self.perm_change), self.content_b))
+        self.assertFalse(self.user1.has_perm(self.get_perm_code(self.perm_change), self.content_b))
 
     def test_shared_group_membership_requires_admin_on_every_trust(self):
         shared = Group.objects.create(name='shared-members')

--- a/trusts/tests.py
+++ b/trusts/tests.py
@@ -24,7 +24,7 @@ from django.test.client import MULTIPART_CONTENT, Client
 from django.http.request import HttpRequest
 
 from trusts.models import Trust, TrustManager, Content, Junction, \
-                          Role, RolePermission, TrustUserPermission
+                          Role, RolePermission, TrustUserPermission, TrustGroup
 from trusts.backends import TrustModelBackend
 from trusts.decorators import permission_required, P, K, G, O
 from tests.models import Category, TestGroupJunction
@@ -56,6 +56,19 @@ def reload_test_users(self):
     self.user_root = User._default_manager.get(pk=self.user_root.pk)
     self.user = User._default_manager.get(pk=self.user.pk)
     self.user1 = User._default_manager.get(pk=self.user1.pk)
+
+
+def enable_local_group_grant(trust, group, *permissions):
+    """Associate ``group`` with ``trust`` and enable the given local grants.
+
+    Each permission must already be in the group's global ceiling
+    (``Group.permissions`` or a role assigned to the group).
+    """
+    trust.groups.add(group)
+    tg = TrustGroup.objects.get(trust=trust, group=group)
+    for perm in permissions:
+        tg.grant_permission(perm)
+    return tg
 
 
 class TrustTest(TestCase):
@@ -461,7 +474,7 @@ class TrustContentTestMixin(ContentModel):
 
         reload_test_users(self)
 
-        self.trust.groups.add(self.group)
+        enable_local_group_grant(self.trust, self.group, self.perm_change)
 
         had = self.user.has_perm(self.get_perm_code(self.perm_change), self.content)
         self.assertTrue(had)
@@ -633,6 +646,7 @@ class RoleTestMixin(object):
         self.group.user_set.add(self.user)
         self.trust.groups.add(self.group)
         Role.objects.get(name='public').groups.add(self.group)
+        enable_local_group_grant(self.trust, self.group, self.perm_read)
 
         self.assertTrue(self.user.has_perm(self.get_perm_code(self.perm_read), self.content1))
         self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_change), self.content1))
@@ -656,6 +670,7 @@ class RoleTestMixin(object):
         self.assertFalse(self.user.has_perm(self.get_perm_code(self.perm_change), self.content1))
 
         trust3.groups.add(self.group)
+        enable_local_group_grant(trust3, self.group, self.perm_read)
 
         reload_test_users(self)
         self.assertTrue(self.user.has_perm(self.get_perm_code(self.perm_read), content3))
@@ -690,7 +705,7 @@ class RoleTestMixin(object):
         group3 = Group(name='write group')
         group3.save()
         Role.objects.get(name='write').groups.add(group3)
-        self.trust.groups.add(group3)
+        enable_local_group_grant(self.trust, group3, self.perm_change)
 
         reload_test_users(self)
         self.assertTrue(self.user.has_perm(self.get_perm_code(self.perm_read), self.content1))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #23.

@chatforthomas — please re-review. The rejected-write blocker is fixed on this same branch.

## Policy

A group permission applies to Trust-controlled content only when **all** of:

```
effective(user, permission, trust, group) =
    user ∈ group
    AND TrustGroup(trust, group) exists
    AND permission ∈ TrustGroup.permissions
    AND permission ∈ Group.permissions
```

`Group.permissions` (plus role assignments on the group) is the global ceiling. `TrustGroup.permissions` is the locally enabled subset. Missing membership, association, local grant, or ceiling → deny.

## What changed

- Explicit `TrustGroup` through model for `Trust.groups` (same table `trusts_trust_groups`).
- Per-Trust `TrustGroupPermission` local grants, using `TRUSTS_GROUP_MODEL` / `TRUSTS_PERMISSION_MODEL`.
- Intersection required in `has_perm()` (`TrustModelBackend`), `ContentQuerySet.permitted()`, `Trust.objects.filter_by_user_content_perm()`, and `trust_grant_q` used by authorization helpers.
- Direct `TrustUserPermission` behavior unchanged.
- Role-derived capabilities remain ceiling only (no local role assignment).
- Application API: `Trust.associate_group` / `grant_group_permission` / `revoke_group_permission` / `set_group_permissions`, plus actor-gated `grant_trust_group_permission` (and related) helpers. Writes outside the ceiling raise `ValidationError` / `AuthorizationDenied`.
- Direct-check / queryset parity kept; SQL `Exists` filters for supported relational paths.
- Incomplete/inconsistent rows fail closed (including a forced local row with no ceiling).

## Review follow-up: atomic rejected writes

Failed local-grant operations no longer leave an empty `TrustGroup` association. `grant_group_permission`, `set_group_permissions`, and `associate_group_with_trust(..., permissions=...)` validate the complete permission set against the global ceiling **before** associating. A previously unassociated group stays unassociated after `ValidationError` / `AuthorizationDenied`. Existing associations are left in place when an extra out-of-ceiling grant is rejected. Regression tests cover those paths.

## Migration

- Forward `trusts.0002_trustgroup` only; `0001_initial` is untouched.
- Existing `Trust.groups` associations become `TrustGroup` rows with **empty** local permission sets. Schema migration preserves association facts and does **not** infer policy. This revokes old implicit group-derived Trust access until local tuples exist.
- Operator command `grandfather_trust_group_permissions`: default `--dry-run` reports exact Trust/group/permission tuples; `--apply` copies the current global ceiling into `TrustGroupPermission`. Not run from schema migration.
- Old/new behavior and migration-bot checklist are in `migrates.md`.

## Tests

- `TrustGroupIntersectionTest` covers the 15 acceptance cases from #23, plus no-partial-mutation regressions for rejected grant/set/associate-with-permissions.
- Existing group/role tests now grant local tuples when they intend to allow access.
- `scripts/verify-legacy-upgrade.py` asserts association preservation, fail-closed group access after `0002`, and dry-run / `--apply` grandfather behavior.

Package version stays `1.0.0.dev0`.

## Out of scope

Parent/child Trust inheritance; explicit deny; per-Trust group membership; SQL compilation of permission conditions; local role assignment on `TrustGroup`; example-project UI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-343d4b55-e342-47aa-9c2d-e2b25b0b2b0e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-343d4b55-e342-47aa-9c2d-e2b25b0b2b0e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

