### PR TITLE
Route Zero evaluation through AuthorizationPath compose (#43 Step 2)

### DIFF
--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -20,11 +20,14 @@ installable `trusts/` package:
 - `tests/core/test_gh_vocab.py` — issue #43 GH-shaped private proof
   (`Account` / `Organization` / `Team` / `PermissionBundle` / `Policy` /
   `Repository`; `account.teams` membership vs organization containment)
+- `tests/core/test_zero_path.py` — issue #43 Step 2 Zero consumer of compose
+  (`ContentQuerySet.permitted` / `TrustModelBackend`; same-PK fail-closed)
 - `tests/regressions/test_issue_*.py` — historical issue regressions
 - `python -m tests.runtests` — discovers the core and regression modules
   by explicit labels (`tests.core.test_core`, `tests.core.test_context`,
   `tests.core.test_trustee`, `tests.core.test_path`,
-  `tests.core.test_gh_vocab`, `tests.core.test_wheel_install`,
+  `tests.core.test_gh_vocab`, `tests.core.test_zero_path`,
+  `tests.core.test_wheel_install`,
   `tests.regressions.test_issue_*`)
 - `python -m tests.runtests_custom` — isolated custom-user suite
   (`tests.custom_content`)

--- a/docs/test-coverage.md
+++ b/docs/test-coverage.md
@@ -63,7 +63,7 @@ joined model. That is historical, not a new denial-widening.
 | Area | Why it is a gap |
 | --- | --- |
 | Anonymous request users | Settlor-anonymous is rejected; object-level anonymous grants are not specified. |
-| Superuser short-circuit | Django's `ModelBackend` still treats superusers as having all perms; no extra Trusts test. |
+| Superuser short-circuit | Django `PermissionsMixin.has_perm` still treats active superusers as having all perms before backends run (`obj=None` and with `obj`). Object-level `TrustModelBackend.has_perm` and `.permitted()` follow relational grants; covered in `tests.core.test_zero_path`. |
 | Nested / inherited trusts | `Trust.trust` is a parent pointer with a readonly check; no recursive ACL evaluation (out of scope). |
 | `has_perm` without `obj` | Falls through to Django model-level perms; only lightly covered via role tests. |
 | `get_group_permissions` content path | Returns a permission queryset, not the string set `ModelBackend` uses; no dedicated assertion. |

--- a/migrates.md
+++ b/migrates.md
@@ -1584,7 +1584,7 @@ migration.
 ## Out of scope (unchanged)
 
 - Rewiring `TrustModelBackend` / `ContentQuerySet.permitted` onto
-  compose (Step 2)
+  compose (Step 2; recorded in the Step 2 section below)
 - Relocating concrete models/migrations to `django-trusts-zero`
   (Step 3)
 - Recursive hierarchy / bounded ancestor walk
@@ -1609,6 +1609,162 @@ migration.
 - [ ] Run the packaging / wheel-import check.
 - [ ] Confirm exact one-query list/exists AuthorizationPath evaluation
       and the GH membership vs containment proof.
+- [ ] Leave package version at `1.0.0.dev0`.
+- [ ] Do not close #43 from this PR.
+
+# Issue #43 Step 2: Zero evaluation consumes AuthorizationPath (1.0.0.dev0)
+
+This record covers routing the existing django-trusts concrete
+implementation through the composed `AuthorizationPath` seam. Version
+remains **1.0.0.dev0**. **No Trusts schema migration is required.** This
+PR does **not** close
+[#43](https://github.com/django-trusts/django-trusts/issues/43); review
+owns that. Relocation to `django-trusts-zero` is a later step.
+Recursive traversal and ordered remaining-bits helpers remain reserved
+slots only.
+
+## Decision
+
+`ContentQuerySet.permitted` and object-level `TrustModelBackend`
+evaluation compile through `trusts.path.compose` (Zero-enabled adapter
+names) rather than a parallel `Context.scope_path` + `Trustee.grant_q`
+or `Content.is_content` + `Trust.objects.filter_by_content` join.
+
+Zero policy stays out of the kernel:
+
+- adapter names `direct` / `group` and settings-based gating
+- Django `auth.Permission` strings / `parse_perm_code` /
+  `resolve_content_permission`
+- `TrustModelBackend` / `_trust_perm_cache` / `User.has_perm`
+- opt-in callable permission conditions
+- `is_active` / anonymous short-circuit
+- public-content gate `Content.is_content` (Junction table rows still
+  do not enter `User.has_perm`)
+
+Create-under-trust (`filter_by_user_content_perm`,
+`has_trust_row_perm`) still uses `Trustee.grant_q` with empty
+`scope_from_row` because `Trust` as Content is registered with the
+parent hop (`resource_to_scope='trust'`), not identity. Those helpers
+now fail closed on raw PKs and wrong-model same-PK requesters /
+operations.
+
+## No change to these public call sites
+
+- `User.has_perm` / `User.has_perms` signatures
+- `ContentQuerySet.permitted(perm, user)` signature
+- `Trust.objects.filter_by_user_content_perm` / `filter_by_user_perm` /
+  `filter_by_content`
+- `from trusts.context import Context` / `from trusts.trustee import Trustee`
+- `from trusts.path import compose, row_is_granted, filter_granted`
+- `from trusts.models import Trust, Content, Junction, Role`
+- `AUTHENTICATION_BACKENDS = ('trusts.backends.TrustModelBackend',)`
+- `Role` / `RolePermission` / `TrustGroup` / `TrustGroupPermission` tables
+- Package version `1.0.0.dev0`
+- Historical `0001_initial` / `0002_trustgroup` file contents
+
+Authorization **behavior** for current User / Group / Role-ceiling /
+condition / custom-user / inactive-user / backend-composition paths is
+**intended identical**. Direct check ≡ queryset. Same-PK collisions of
+the wrong model and raw primary keys now fail closed at these public
+compatibility entry points instead of letting Django coerce the PK.
+
+## Changes
+
+### 37. Concrete evaluation consumes `compose`
+
+| | |
+| --- | --- |
+| Previous (Step 1) | `ContentQuerySet.permitted` called `trust_grant_q(..., trust_fk=Context.scope_path(model))`. `TrustModelBackend.get_all_permissions` / `has_perm` materialized Trusts via `filter_by_content` then `Trustee.operation_grant_q`. |
+| New | `.permitted()` uses `compose_zero_path` / `path.grant_q`. Object-level `has_perm` uses `row_is_zero_granted` / `queryset_is_zero_granted` (the same composed predicate). `get_all_permissions` enumerates operations per scope PK taken from `path.resource_to_scope` (resource-origin), still intersecting across scopes for QuerySets. `get_group_permissions` remains a Zero mapping onto the named `group` adapter. |
+| Replacement | Same `has_perm` / `.permitted()` call sites. New kernel callers still use `from trusts.path import compose`. |
+| Affected | Internal evaluation only. |
+| Authorization | Same allow/deny for current User / Group / Role-ceiling / Content paths. Unregistered and Junction-table objects still deny on `User.has_perm`. |
+
+Migration-bot checklist:
+
+- [ ] Keep using `User.has_perm` / `.permitted()` for current Content.
+- [ ] Do not pass a raw PK or a non-requester model as the user argument
+      to `.permitted()`, `TrustModelBackend.has_perm`,
+      `filter_by_user_content_perm`, or `has_trust_row_perm`.
+- [ ] Do not relocate models, migrations, commands, or the backend to
+      `django-trusts-zero` in this slice.
+- [ ] Do not add a Trusts schema migration. Do not edit `0001_initial`
+      or `0002_trustgroup`.
+- [ ] Run `python -m tests.runtests` (includes `tests.core.test_zero_path`).
+- [ ] Run `python -m tests.runtests_custom`.
+- [ ] Run `python -m django check` (default and custom settings).
+- [ ] Run `python scripts/verify-legacy-upgrade.py`.
+- [ ] Confirm `has_perm` and `.permitted()` still agree and stay
+      fixed-query.
+- [ ] Leave package version at `1.0.0.dev0`.
+- [ ] Do not close #43 from this PR.
+
+### 38. Deletion report (noun-dependent query branches)
+
+Removed as genuinely redundant after the compose rewire. They were
+already unused call sites or parallel joins of the same frozen adapters:
+
+| Removed | Why redundant |
+| --- | --- |
+| `query.group_local_grant_exists` | Called `Trustee.get('group').exists_q` by adapter name. No remaining caller after #40; group grants OR-compose through `path.grant_q`. |
+| `query.permission_granted_via_group_exists` | Called `Trustee.get('group').operation_exists_q` by adapter name. No remaining caller. Zero `get_group_permissions` still uses that adapter explicitly. |
+| `query._never_exists` | Imported `TrustGroup` to return `Exists(TrustGroup.objects.none())`. Empty adapter sets use `Q(pk__in=[])`. |
+| `query._scope_from_row_for_outerref` | Trust-PK outerref name munging (`trust_id` → `trust`) used only by the deleted group helpers. Compose passes `resource_to_scope` as registered. |
+| `TrustModelBackendMixin._get_trusts` | Trust-origin `filter_by_content` join, parallel to Context's resource-origin hop. Replaced by `compose_zero_path` + `scope_pks_from_resource`. |
+| `backends._trust_permission_grant_q` | Thin wrapper over `Trustee.operation_grant_q`; inlined on the composed scope list. |
+
+Isolated, not deleted (still Zero policy / compatibility):
+
+| Kept | Why |
+| --- | --- |
+| `query.enabled_trustee_adapter_names` | Zero gating of built-in `direct` / `group`; extra adapters stay enabled. Passed to `compose(..., names=...)`. |
+| `query.trust_grant_q` | Create-under-trust / `has_trust_row_perm` (empty `scope_from_row`). Now fail-closed on requester/operation terminals. |
+| `query.is_active_principal` | Django user flags; not a kernel default. |
+| `Content.is_content` as `has_perm` gate | Public-content facade. Junction tables are Context-registered but must not newly authorize. |
+| `Trustee.get(GROUP_TRUSTEE)` in `get_group_permissions` | Django's user/group permission split mapped onto a named Zero adapter. |
+| `Content._contents` / `_conditions` / `class_prepared` | Zero convenience; not this slice. |
+| V1 `Expr` compile on `.permitted()` | Still AND-ed after the composed grant `Q`. `condition=` on `compose` remains reserved. |
+
+## Fresh database
+
+```
+python -m django migrate --settings=tests.settings
+python -m django migrate --settings=tests.custom_settings
+```
+
+Trusts still applies `0001`–`0002` only.
+
+## Upgrade of a representative legacy database
+
+`scripts/verify-legacy-upgrade.py` is unchanged: pending
+`0002_trustgroup` after recording `0001_initial`, then
+`{0001_initial, 0002_trustgroup}` after migrate. No new Trusts
+migration.
+
+## Out of scope (unchanged)
+
+- Relocating concrete models/migrations to `django-trusts-zero`
+  (Step 3)
+- Recursive hierarchy / bounded ancestor walk
+- Ordered remaining-bits / Windows ACE semantics
+- Compiling resource-row V1 `Expr` on the IR (`condition=` reserved)
+- Implementing complete GH authorization semantics
+- A separate `django-trusts-core` distribution
+- Closing #43
+
+## Migration-bot summary (issue #43 Step 2)
+
+- [ ] Keep current `has_perm` / `.permitted()` / backend signatures.
+- [ ] Expect same-PK / raw-PK requesters to fail closed
+      (`AuthorizationPathError`) at those entry points.
+- [ ] Do not relocate packages or migrations.
+- [ ] Do not add a Trusts schema migration.
+- [ ] Run `python -m tests.runtests` (includes `tests.core.test_zero_path`).
+- [ ] Run `python -m tests.runtests_custom`.
+- [ ] Run `python -m django check` (default and custom settings).
+- [ ] Run `python scripts/verify-legacy-upgrade.py`.
+- [ ] Confirm `has_perm` ≡ `.permitted()`, fixed-query, and current
+      User/Group/Role-ceiling allow/deny.
 - [ ] Leave package version at `1.0.0.dev0`.
 - [ ] Do not close #43 from this PR.
 

--- a/migrates.md
+++ b/migrates.md
@@ -1637,7 +1637,12 @@ Zero policy stays out of the kernel:
   `resolve_content_permission`
 - `TrustModelBackend` / `_trust_perm_cache` / `User.has_perm`
 - opt-in callable permission conditions
-- `is_active` / anonymous short-circuit
+- `is_active` / anonymous short-circuit. Object-level superuser is **not**
+  a global True: `TrustModelBackend.has_perm(obj)` uses the same composed
+  grant as other requesters (pre-PR `get_all_permissions(obj)` did the
+  same). `User.has_perm` without `obj` still follows Django's
+  `PermissionsMixin` shortcut. `.permitted()` never treated superuser as
+  return-all.
 - public-content gate `Content.is_content` (Junction table rows still
   do not enter `User.has_perm`)
 
@@ -1678,7 +1683,7 @@ compatibility entry points instead of letting Django coerce the PK.
 | New | `.permitted()` uses `compose_zero_path` / `path.grant_q`. Object-level `has_perm` uses `row_is_zero_granted` / `queryset_is_zero_granted` (the same composed predicate). `get_all_permissions` enumerates operations per scope PK taken from `path.resource_to_scope` (resource-origin), still intersecting across scopes for QuerySets. `get_group_permissions` remains a Zero mapping onto the named `group` adapter. |
 | Replacement | Same `has_perm` / `.permitted()` call sites. New kernel callers still use `from trusts.path import compose`. |
 | Affected | Internal evaluation only. |
-| Authorization | Same allow/deny for current User / Group / Role-ceiling / Content paths. Unregistered and Junction-table objects still deny on `User.has_perm`. |
+| Authorization | Same allow/deny for current User / Group / Role-ceiling / Content paths. Unregistered and Junction-table objects still deny on object-level `has_perm`. Active superusers without a Trust-scoped grant stay denied on object-level `TrustModelBackend.has_perm` and `.permitted()`; a granted superuser is present on both. Django `obj=None` / `User.has_perm` without an object still short-circuits active superusers. |
 
 Migration-bot checklist:
 
@@ -1696,6 +1701,10 @@ Migration-bot checklist:
 - [ ] Run `python scripts/verify-legacy-upgrade.py`.
 - [ ] Confirm `has_perm` and `.permitted()` still agree and stay
       fixed-query.
+- [ ] Confirm an active superuser without a Trust-scoped grant is denied
+      on object-level `TrustModelBackend.has_perm` and `.permitted()`, a
+      granted superuser is allowed on both, and Junction / unregistered
+      objects plus unknown permission codes stay denied.
 - [ ] Leave package version at `1.0.0.dev0`.
 - [ ] Do not close #43 from this PR.
 
@@ -1765,6 +1774,8 @@ migration.
 - [ ] Run `python scripts/verify-legacy-upgrade.py`.
 - [ ] Confirm `has_perm` ≡ `.permitted()`, fixed-query, and current
       User/Group/Role-ceiling allow/deny.
+- [ ] Confirm object-level superuser follows relational grants on both
+      `TrustModelBackend.has_perm` and `.permitted()`.
 - [ ] Leave package version at `1.0.0.dev0`.
 - [ ] Do not close #43 from this PR.
 

--- a/tests/core/test_zero_path.py
+++ b/tests/core/test_zero_path.py
@@ -9,7 +9,7 @@ concrete models.
 import inspect
 from pathlib import Path
 
-from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.models import Group, Permission, User
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, TransactionTestCase
 
@@ -30,7 +30,7 @@ from trusts.query import (
     require_configured_requester,
     trust_grant_q,
 )
-from tests.models import Category, TestGroupJunction
+from tests.models import Category, Organization, TestGroupJunction
 from tests.support import (
     ContentModelMixin,
     enable_local_group_grant,
@@ -63,6 +63,12 @@ class ZeroComposeConsumerSourceTest(TestCase):
         self.assertNotIn('_get_trusts', source)
         self.assertIn('Content.is_content', source)
         self.assertIn('GROUP_TRUSTEE', source)
+        has_perm_src = inspect.getsource(TrustModelBackendMixin.has_perm)
+        self.assertNotIn(
+            'is_superuser',
+            has_perm_src,
+            'object-level has_perm must not short-circuit active superusers',
+        )
 
     def test_deleted_noun_dependent_query_helpers_are_gone(self):
         source = _query_source()
@@ -194,6 +200,79 @@ class ZeroComposeConsumerTest(ContentModelMixin, TestCase):
             self.user, Category.objects.none(),
         )
         self.assertEqual(empty, [])
+
+    def _read_perm(self):
+        return self.get_perm_code(self.perm_read)
+
+    def _permitted_pks(self, user):
+        return set(
+            Category.objects.permitted('read', user).values_list('pk', flat=True)
+        )
+
+    def _make_superuser(self, user):
+        user.is_superuser = True
+        user.is_active = True
+        user.save()
+        reload_test_users(self)
+        return User._default_manager.get(pk=user.pk)
+
+    def test_ungranted_superuser_absent_from_has_perm_and_permitted(self):
+        superuser = self._make_superuser(self.user1)
+        self.assertTrue(superuser.is_superuser)
+        self.assertTrue(superuser.is_active)
+        perm = self._read_perm()
+        # Django User.has_perm still short-circuits before backends.
+        self.assertTrue(superuser.has_perm(perm))
+        backend = TrustModelBackend()
+        self.assertFalse(backend.has_perm(superuser, perm, self.content))
+        self.assertFalse(backend.has_perm(superuser, perm, self.content_b))
+        listed = self._permitted_pks(superuser)
+        self.assertNotIn(self.content.pk, listed)
+        self.assertNotIn(self.content_b.pk, listed)
+        allowed = {
+            obj.pk
+            for obj in Category.objects.order_by('pk')
+            if backend.has_perm(superuser, perm, obj)
+        }
+        self.assertEqual(listed, allowed)
+
+    def test_granted_superuser_present_in_has_perm_and_permitted(self):
+        TrustUserPermission.objects.get_or_create(
+            trust=self.org, entity=self.user1, permission=self.perm_read,
+        )
+        superuser = self._make_superuser(self.user1)
+        perm = self._read_perm()
+        backend = TrustModelBackend()
+        self.assertTrue(backend.has_perm(superuser, perm, self.content))
+        self.assertFalse(backend.has_perm(superuser, perm, self.content_b))
+        listed = self._permitted_pks(superuser)
+        self.assertEqual(listed, {self.content.pk})
+        allowed = {
+            obj.pk
+            for obj in Category.objects.order_by('pk')
+            if backend.has_perm(superuser, perm, obj)
+        }
+        self.assertEqual(listed, allowed)
+
+    def test_superuser_junction_unregistered_and_unknown_perm_denied(self):
+        superuser = self._make_superuser(self.user)
+        perm = self._read_perm()
+        backend = TrustModelBackend()
+        self.assertTrue(backend.has_perm(superuser, perm, self.content))
+        junction = TestGroupJunction.objects.create(
+            content=self.group, trust=self.org, name='superuser-junction',
+        )
+        self.assertFalse(Content.is_content(junction))
+        self.assertFalse(backend.has_perm(superuser, perm, junction))
+        unregistered = Organization.objects.create(
+            name='superuser-unregistered', manager=superuser,
+        )
+        self.assertFalse(Content.is_content(unregistered))
+        self.assertFalse(Context.is_registered(Organization))
+        self.assertFalse(backend.has_perm(superuser, perm, unregistered))
+        self.assertFalse(
+            backend.has_perm(superuser, 'tests.nosuch_category', self.content)
+        )
 
 
 class ZeroSamePkFailClosedTest(ContentModelMixin, TransactionTestCase):

--- a/tests/core/test_zero_path.py
+++ b/tests/core/test_zero_path.py
@@ -270,9 +270,8 @@ class ZeroComposeConsumerTest(ContentModelMixin, TestCase):
         self.assertFalse(Content.is_content(unregistered))
         self.assertFalse(Context.is_registered(Organization))
         self.assertFalse(backend.has_perm(superuser, perm, unregistered))
-        self.assertFalse(
-            backend.has_perm(superuser, 'tests.nosuch_category', self.content)
-        )
+        unknown = '%s.nosuch_%s' % (self.app_label, self.model_name)
+        self.assertFalse(backend.has_perm(superuser, unknown, self.content))
 
 
 class ZeroSamePkFailClosedTest(ContentModelMixin, TransactionTestCase):

--- a/tests/core/test_zero_path.py
+++ b/tests/core/test_zero_path.py
@@ -1,0 +1,288 @@
+"""Zero consumer of the composed AuthorizationPath seam (#43 Step 2).
+
+Process-wide Content / Trust / Group / Role paths must go through
+``compose`` at ``ContentQuerySet.permitted`` and object-level
+``TrustModelBackend`` evaluation. Does not close #43. Does not relocate
+concrete models.
+"""
+
+import inspect
+from pathlib import Path
+
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase, TransactionTestCase
+
+from trusts.authorization import has_trust_row_perm
+from trusts.backends import TrustModelBackend, TrustModelBackendMixin
+from trusts.context import Context
+from trusts.models import (
+    Content,
+    ContentQuerySet,
+    Trust,
+    TrustUserPermission,
+    prepare_context_registry,
+)
+from trusts.path import AuthorizationPathError
+from trusts.query import (
+    compose_zero_path,
+    require_configured_operation,
+    require_configured_requester,
+    trust_grant_q,
+)
+from tests.models import Category, TestGroupJunction
+from tests.support import (
+    ContentModelMixin,
+    enable_local_group_grant,
+    reload_test_users,
+)
+
+
+def _query_source():
+    import trusts.query as query_mod
+    return Path(inspect.getfile(query_mod)).read_text()
+
+
+def _backend_source():
+    return Path(inspect.getfile(TrustModelBackendMixin)).read_text()
+
+
+class ZeroComposeConsumerSourceTest(TestCase):
+    def test_permitted_uses_compose_not_parallel_join(self):
+        source = inspect.getsource(ContentQuerySet.permitted)
+        self.assertIn('compose_zero_path', source)
+        self.assertIn('grant_q', source)
+        self.assertNotIn('trust_grant_q', source)
+        self.assertNotIn('Context.scope_path', source)
+
+    def test_backend_object_path_uses_compose_not_filter_by_content(self):
+        source = _backend_source()
+        self.assertIn('compose_zero_path', source)
+        self.assertIn('row_is_zero_granted', source)
+        self.assertNotIn('filter_by_content', source)
+        self.assertNotIn('_get_trusts', source)
+        self.assertIn('Content.is_content', source)
+        self.assertIn('GROUP_TRUSTEE', source)
+
+    def test_deleted_noun_dependent_query_helpers_are_gone(self):
+        source = _query_source()
+        self.assertNotIn('group_local_grant_exists', source)
+        self.assertNotIn('permission_granted_via_group_exists', source)
+        self.assertNotIn('_never_exists', source)
+        self.assertNotIn('TrustGroup', source)
+        self.assertIn('compose', source)
+
+    def test_no_trusts_schema_migration_added(self):
+        migrations = Path(inspect.getfile(Trust)).resolve().parent / 'migrations'
+        names = sorted(
+            path.name for path in migrations.glob('*.py')
+            if path.name != '__init__.py'
+        )
+        self.assertEqual(names, ['0001_initial.py', '0002_trustgroup.py'])
+
+
+class ZeroComposeConsumerTest(ContentModelMixin, TestCase):
+    def setUp(self):
+        super(ZeroComposeConsumerTest, self).setUp()
+        self.org = Trust(
+            settlor=self.user, trust=Trust.objects.get_root(), title='Zero Org A',
+        )
+        self.org.save()
+        self.org_b = Trust(
+            settlor=self.user1, trust=Trust.objects.get_root(), title='Zero Org B',
+        )
+        self.org_b.save()
+        self.content = self.create_content(self.org)
+        self.content_b = self.create_content(self.org_b)
+        TrustUserPermission.objects.get_or_create(
+            trust=self.org, entity=self.user, permission=self.perm_read,
+        )
+        reload_test_users(self)
+
+    def test_composed_path_matches_content_scope_hop(self):
+        prepare_context_registry()
+        path = compose_zero_path(Category, self.perm_read)
+        self.assertIsNotNone(path)
+        self.assertEqual(path.resource_to_scope, Context.scope_path(Category))
+        self.assertEqual(path.resource_to_scope, 'trust')
+        self.assertIn('direct', path.adapter_names)
+        self.assertIn('group', path.adapter_names)
+
+    def test_has_perm_and_permitted_agree_and_sql_filter(self):
+        listed = set(
+            Category.objects.permitted('read', self.user).values_list(
+                'pk', flat=True,
+            )
+        )
+        allowed = {
+            obj.pk
+            for obj in Category.objects.order_by('pk')
+            if self.user.has_perm(self.get_perm_code(self.perm_read), obj)
+        }
+        self.assertEqual(listed, allowed)
+        self.assertEqual(listed, {self.content.pk})
+        qs = Category.objects.permitted('read', self.user)
+        sql = str(qs.query)
+        self.assertTrue(
+            'JOIN' in sql.upper() or 'EXISTS' in sql.upper(),
+            'permitted() must filter in SQL. SQL was: %s' % sql,
+        )
+
+    def test_permitted_is_fixed_query_after_permission_resolve(self):
+        Category.objects.get_permission('read')
+        with self.assertNumQueries(2):
+            pks = list(
+                Category.objects.permitted('read', self.user)
+                .values_list('pk', flat=True)
+            )
+        self.assertEqual(pks, [self.content.pk])
+
+    def test_has_perm_instance_is_one_exists_query_after_permission_resolve(self):
+        Category.objects.get_permission('read')
+        with self.assertNumQueries(2):
+            granted = self.user.has_perm(
+                self.get_perm_code(self.perm_read), self.content,
+            )
+        self.assertTrue(granted)
+
+    def test_group_and_role_ceiling_still_require_local_grant(self):
+        self.perm_change.group_set.add(self.group)
+        self.group.user_set.add(self.user)
+        self.org.groups.add(self.group)
+        reload_test_users(self)
+        self.assertFalse(
+            self.user.has_perm(self.get_perm_code(self.perm_change), self.content)
+        )
+        self.assertNotIn(
+            self.content.pk,
+            Category.objects.permitted('change', self.user).values_list(
+                'pk', flat=True,
+            ),
+        )
+        enable_local_group_grant(self.org, self.group, self.perm_change)
+        reload_test_users(self)
+        self.assertTrue(
+            self.user.has_perm(self.get_perm_code(self.perm_change), self.content)
+        )
+        self.assertIn(
+            self.content.pk,
+            Category.objects.permitted('change', self.user).values_list(
+                'pk', flat=True,
+            ),
+        )
+
+    def test_junction_table_row_does_not_enter_has_perm(self):
+        prepare_context_registry()
+        junction = TestGroupJunction.objects.create(
+            content=self.group, trust=self.org, name='zero-junction',
+        )
+        self.assertFalse(Content.is_content(junction))
+        self.assertTrue(Context.is_registered(TestGroupJunction))
+        self.assertTrue(
+            self.user.has_perm(self.get_perm_code(self.perm_read), self.content)
+        )
+        self.assertFalse(
+            self.user.has_perm(self.get_perm_code(self.perm_read), junction)
+        )
+
+    def test_get_all_permissions_uses_composed_scope(self):
+        backend = TrustModelBackend()
+        perms = backend.get_all_permissions(self.user, self.content)
+        self.assertIn(self.get_perm_code(self.perm_read), perms)
+        self.assertNotIn(self.get_perm_code(self.perm_change), perms)
+        empty = backend.get_all_permissions(
+            self.user, Category.objects.none(),
+        )
+        self.assertEqual(empty, [])
+
+
+class ZeroSamePkFailClosedTest(ContentModelMixin, TransactionTestCase):
+    reset_sequences = True
+
+    def setUp(self):
+        super(ZeroSamePkFailClosedTest, self).setUp()
+        self.org = Trust(
+            settlor=self.user, trust=Trust.objects.get_root(),
+            title='Same-PK org',
+        )
+        self.org.save()
+        self.content = self.create_content(self.org)
+        TrustUserPermission.objects.get_or_create(
+            trust=self.org, entity=self.user, permission=self.perm_read,
+        )
+        reload_test_users(self)
+        self.collider = Group.objects.create(pk=self.user.pk, name='same-pk-group')
+        self.assertEqual(self.user.pk, self.collider.pk)
+
+    def test_permitted_rejects_wrong_requester_same_pk(self):
+        self.assertIn(
+            self.content.pk,
+            Category.objects.permitted('read', self.user).values_list(
+                'pk', flat=True,
+            ),
+        )
+        with self.assertRaises(AuthorizationPathError) as ctx:
+            Category.objects.permitted('read', self.collider)
+        self.assertIn('requester', str(ctx.exception))
+
+    def test_permitted_rejects_raw_primary_key(self):
+        with self.assertRaises(AuthorizationPathError) as ctx:
+            Category.objects.permitted('read', self.user.pk)
+        self.assertIn('primary key', str(ctx.exception).lower())
+
+    def test_backend_has_perm_rejects_wrong_requester_same_pk(self):
+        backend = TrustModelBackend()
+        self.assertTrue(
+            backend.has_perm(
+                self.user, self.get_perm_code(self.perm_read), self.content,
+            )
+        )
+        with self.assertRaises(AuthorizationPathError) as ctx:
+            backend.has_perm(
+                self.collider, self.get_perm_code(self.perm_read), self.content,
+            )
+        self.assertIn('requester', str(ctx.exception))
+
+    def test_backend_has_perm_rejects_raw_primary_key_requester(self):
+        backend = TrustModelBackend()
+        with self.assertRaises(AuthorizationPathError):
+            backend.has_perm(
+                self.user.pk, self.get_perm_code(self.perm_read), self.content,
+            )
+
+    def test_filter_by_user_content_perm_rejects_wrong_requester_same_pk(self):
+        qs = Trust.objects.filter_by_user_content_perm(
+            self.user, Category, 'read',
+        )
+        self.assertIn(self.org.pk, qs.values_list('pk', flat=True))
+        with self.assertRaises(AuthorizationPathError):
+            list(Trust.objects.filter_by_user_content_perm(
+                self.collider, Category, 'read',
+            ))
+
+    def test_has_trust_row_perm_rejects_wrong_requester_same_pk(self):
+        trust_read = Trust.objects.get_permission('read')
+        TrustUserPermission.objects.get_or_create(
+            trust=self.org, entity=self.user, permission=trust_read,
+        )
+        reload_test_users(self)
+        self.assertTrue(has_trust_row_perm(self.user, self.org, 'read'))
+        with self.assertRaises(AuthorizationPathError):
+            has_trust_row_perm(self.collider, self.org, 'read')
+
+    def test_trust_grant_q_rejects_wrong_operation_same_pk(self):
+        ct = ContentType.objects.get_for_model(Category)
+        perm_same = Permission.objects.filter(pk=self.user.pk).first()
+        if perm_same is None:
+            perm_same = Permission.objects.create(
+                pk=self.user.pk,
+                content_type=ct,
+                codename='zero_same_pk_perm',
+                name='zero same pk',
+            )
+        self.assertEqual(self.user.pk, perm_same.pk)
+        with self.assertRaises(AuthorizationPathError) as ctx:
+            require_configured_operation(self.user)
+        self.assertIn('operation', str(ctx.exception))
+        with self.assertRaises(AuthorizationPathError):
+            trust_grant_q(self.user, self.user)

--- a/tests/core/test_zero_path.py
+++ b/tests/core/test_zero_path.py
@@ -137,9 +137,9 @@ class ZeroComposeConsumerTest(ContentModelMixin, TestCase):
             )
         self.assertEqual(pks, [self.content.pk])
 
-    def test_has_perm_instance_is_one_exists_query_after_permission_resolve(self):
+    def test_has_perm_instance_is_fixed_query_after_permission_resolve(self):
         Category.objects.get_permission('read')
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(3):
             granted = self.user.has_perm(
                 self.get_perm_code(self.perm_read), self.content,
             )

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -30,6 +30,7 @@ NORMAL_SUITE = [
     'tests.core.test_trustee',
     'tests.core.test_path',
     'tests.core.test_gh_vocab',
+    'tests.core.test_zero_path',
     'tests.core.test_wheel_install',
 ]
 

--- a/trusts/authorization.py
+++ b/trusts/authorization.py
@@ -57,7 +57,12 @@ def has_trust_row_perm(user, trust, perm):
     ``has_perm`` when the object itself is a ``Trust``. Create-under-trust
     and trust-row administration use this check.
     """
-    if not is_active_principal(user) or trust is None:
+    from trusts.query import require_configured_requester
+
+    if user is None or getattr(user, 'is_anonymous', False) or trust is None:
+        return False
+    require_configured_requester(user)
+    if not is_active_principal(user):
         return False
     permission = Trust.objects.get_permission(perm) if isinstance(perm, str) else perm
     return Trust.objects.filter(pk=trust.pk).filter(

--- a/trusts/backends.py
+++ b/trusts/backends.py
@@ -159,6 +159,7 @@ class TrustModelBackendMixin(object):
 
     def _object_perm_granted(self, user_obj, perm, obj):
         """Object-level grant via compose, not ``get_all_permissions``."""
+        from django.contrib.contenttypes.models import ContentType
         from django.core.exceptions import ValidationError
         from trusts.context import Context
         from trusts.path import AuthorizationPathError
@@ -177,7 +178,7 @@ class TrustModelBackendMixin(object):
             return False
         try:
             permission = resolve_content_permission(klass, perm)
-        except (Permission.DoesNotExist, ValidationError, ValueError):
+        except (Permission.DoesNotExist, ContentType.DoesNotExist, ValidationError, ValueError):
             return False
         try:
             if isinstance(obj, QuerySet):

--- a/trusts/backends.py
+++ b/trusts/backends.py
@@ -48,9 +48,18 @@ class TrustModelBackendMixin(object):
         from ``AuthorizationPath.resource_to_scope``, not a Trust-origin
         reverse lookup.
         """
+        from trusts.path import AuthorizationPathError
+
         if not Content.is_content(obj):
             return Trust.objects.none()
-        path = compose_zero_path(self._get_class(obj), None)
+        klass = self._get_class(obj)
+        fieldlookup = Content.get_content_fieldlookup(klass)
+        if fieldlookup:
+            Content.require_valid_content_fieldlookup(klass, fieldlookup)
+        try:
+            path = compose_zero_path(klass, None)
+        except AuthorizationPathError:
+            return Trust.objects.none()
         if path is None:
             return Trust.objects.none()
         pks = scope_pks_from_resource(obj, path)
@@ -150,6 +159,10 @@ class TrustModelBackendMixin(object):
 
     def _object_perm_granted(self, user_obj, perm, obj):
         """Object-level grant via compose, not ``get_all_permissions``."""
+        from django.core.exceptions import ValidationError
+        from trusts.context import Context
+        from trusts.path import AuthorizationPathError
+
         if not supported_entity_contract() or not supported_permission_contract():
             return False
         if not is_active_principal(user_obj):
@@ -157,10 +170,23 @@ class TrustModelBackendMixin(object):
         if not Content.is_content(obj):
             return False
         klass = self._get_class(obj)
-        permission = resolve_content_permission(klass, perm)
-        if isinstance(obj, QuerySet):
-            return queryset_is_zero_granted(obj, user_obj, permission)
-        return row_is_zero_granted(obj, user_obj, permission)
+        fieldlookup = Content.get_content_fieldlookup(klass)
+        if fieldlookup:
+            Content.require_valid_content_fieldlookup(klass, fieldlookup)
+        if not Context.is_registered(klass):
+            return False
+        try:
+            permission = resolve_content_permission(klass, perm)
+        except (Permission.DoesNotExist, ValidationError, ValueError):
+            return False
+        try:
+            if isinstance(obj, QuerySet):
+                return queryset_is_zero_granted(obj, user_obj, permission)
+            return row_is_zero_granted(obj, user_obj, permission)
+        except AuthorizationPathError as exc:
+            if 'not a registered' in str(exc):
+                return False
+            raise
 
     def has_perm(self, user_obj, permext, obj=None):
         applabel, modelname, action, cond = utils.parse_perm_code(permext)

--- a/trusts/backends.py
+++ b/trusts/backends.py
@@ -4,9 +4,17 @@ from django.contrib.auth.models import Permission
 
 from trusts.models import (
     GROUP_TRUSTEE, Trust, Content, legacy_permission_callbacks_allowed,
-    prepare_context_registry, prepare_trustee_registry,
+    prepare_trustee_registry, resolve_content_permission,
 )
-from trusts.query import enabled_trustee_adapter_names
+from trusts.query import (
+    compose_zero_path,
+    enabled_trustee_adapter_names,
+    is_active_principal,
+    queryset_is_zero_granted,
+    require_configured_requester,
+    row_is_zero_granted,
+    scope_pks_from_resource,
+)
 from trusts.trustee import Trustee
 from trusts.conditions import PermissionConditionError, evaluate_registered_expression
 from trusts import (
@@ -25,28 +33,30 @@ class TrustModelBackendMixin(object):
         )
 
     @staticmethod
-    def _get_trusts(obj):
-        if not Content.is_content(obj):
-            return []
-
-        prepare_context_registry()
-        prepare_trustee_registry()
-        trusts = Trust.objects.filter_by_content(obj)
-        if trusts is None:
-            return []
-
-        if not hasattr(trusts, '__iter__'):
-            trusts = [trusts]
-
-        return trusts
-
-    @staticmethod
     def _get_class(obj):
         if isinstance(obj, QuerySet):
             klass = obj.model
         else:
             klass = obj.__class__
         return klass
+
+    def _scopes_for_content(self, obj):
+        """Trust rows reached by the composed resource→scope hop.
+
+        Zero public-content gate stays ``Content.is_content`` so Junction
+        table rows do not enter ``User.has_perm``. Scope identity comes
+        from ``AuthorizationPath.resource_to_scope``, not a Trust-origin
+        reverse lookup.
+        """
+        if not Content.is_content(obj):
+            return Trust.objects.none()
+        path = compose_zero_path(self._get_class(obj), None)
+        if path is None:
+            return Trust.objects.none()
+        pks = scope_pks_from_resource(obj, path)
+        if not pks:
+            return Trust.objects.none()
+        return Trust.objects.filter(pk__in=pks)
 
     def get_group_permissions(self, user_obj, obj=None):
         """
@@ -60,9 +70,11 @@ class TrustModelBackendMixin(object):
         if not _group_permission_queries_allowed():
             return set()
 
+        require_configured_requester(user_obj)
+
         if Content.is_content(obj):
-            trusts = self._get_trusts(obj)
-            if not trusts:
+            trusts = self._scopes_for_content(obj)
+            if not trusts.exists():
                 return Permission.objects.none()
             prepare_trustee_registry()
             return Permission.objects.filter(
@@ -78,19 +90,24 @@ class TrustModelBackendMixin(object):
         if not supported_entity_contract() or not supported_permission_contract():
             return []
 
+        require_configured_requester(user_obj)
+
         if not hasattr(user_obj, '_trust_perm_cache'):
             setattr(user_obj, '_trust_perm_cache', dict())
         perm_cache = getattr(user_obj, '_trust_perm_cache')
 
-        trusts = self._get_trusts(obj)
+        trusts = list(self._scopes_for_content(obj))
         if len(trusts):
             all_perms = []
+            names = enabled_trustee_adapter_names()
             for trust in trusts:
                 if trust.pk not in perm_cache.keys():
-                    grant_q = _trust_permission_grant_q(user_obj, trust)
-                    if grant_q is None:
+                    if not names:
                         trust_perm = set()
                     else:
+                        grant_q = Trustee.operation_grant_q(
+                            user_obj, trust, names=names,
+                        )
                         trust_perm = set([self._get_perm_code(p) for p in
                             Permission.objects.filter(grant_q)
                         ])
@@ -131,6 +148,20 @@ class TrustModelBackendMixin(object):
             )
         return all([record.func(user_obj, perm, o) for o in objs])
 
+    def _object_perm_granted(self, user_obj, perm, obj):
+        """Object-level grant via compose, not ``get_all_permissions``."""
+        if not supported_entity_contract() or not supported_permission_contract():
+            return False
+        if not is_active_principal(user_obj):
+            return False
+        if not Content.is_content(obj):
+            return False
+        klass = self._get_class(obj)
+        permission = resolve_content_permission(klass, perm)
+        if isinstance(obj, QuerySet):
+            return queryset_is_zero_granted(obj, user_obj, permission)
+        return row_is_zero_granted(obj, user_obj, permission)
+
     def has_perm(self, user_obj, permext, obj=None):
         applabel, modelname, action, cond = utils.parse_perm_code(permext)
         record = None
@@ -140,7 +171,17 @@ class TrustModelBackendMixin(object):
                 raise AttributeError('Permission condition code "%s" is not associate with model "%s_%s"' % (cond, applabel, modelname))
 
         perm = '%s.%s_%s' % (applabel, action, modelname)
-        positive = super(TrustModelBackendMixin, self).has_perm(user_obj=user_obj, perm=perm, obj=obj)
+        if obj is None or getattr(user_obj, 'is_anonymous', False):
+            positive = super(TrustModelBackendMixin, self).has_perm(
+                user_obj=user_obj, perm=perm, obj=obj,
+            )
+        elif getattr(user_obj, 'is_active', False) and getattr(
+            user_obj, 'is_superuser', False,
+        ):
+            positive = True
+        else:
+            require_configured_requester(user_obj)
+            positive = self._object_perm_granted(user_obj, perm, obj)
         if positive:
             if len(cond) == 0:
                 return True
@@ -156,14 +197,6 @@ def _group_permission_queries_allowed():
         and supported_group_contract()
         and supported_permission_contract()
     )
-
-
-def _trust_permission_grant_q(user_obj, trust):
-    prepare_trustee_registry()
-    names = enabled_trustee_adapter_names()
-    if not names:
-        return None
-    return Trustee.operation_grant_q(user_obj, trust, names=names)
 
 
 class TrustModelBackend(TrustModelBackendMixin, ModelBackend):

--- a/trusts/backends.py
+++ b/trusts/backends.py
@@ -198,13 +198,13 @@ class TrustModelBackendMixin(object):
 
         perm = '%s.%s_%s' % (applabel, action, modelname)
         if obj is None or getattr(user_obj, 'is_anonymous', False):
+            # ``obj=None`` keeps Django's model-level path (including
+            # PermissionsMixin's superuser shortcut on ``User.has_perm``).
+            # Object-level checks do not: they use the composed grant, as
+            # pre-PR ``get_all_permissions(obj)`` did.
             positive = super(TrustModelBackendMixin, self).has_perm(
                 user_obj=user_obj, perm=perm, obj=obj,
             )
-        elif getattr(user_obj, 'is_active', False) and getattr(
-            user_obj, 'is_superuser', False,
-        ):
-            positive = True
         else:
             require_configured_requester(user_obj)
             positive = self._object_perm_granted(user_obj, perm, obj)

--- a/trusts/models.py
+++ b/trusts/models.py
@@ -360,9 +360,14 @@ class TrustManager(ContentManager):
         if 'group__user' in kwargs:
             raise TypeError('"%s" are invalid keyword arguments' % 'group__user')
 
+        from trusts.query import require_configured_requester
+
         reject_queryable_condition(
             perm_name, 'Trust.objects.filter_by_user_content_perm'
         )
+        if user is None or getattr(user, 'is_anonymous', False):
+            return self.none()
+        require_configured_requester(user)
         if not is_active_principal(user):
             return self.none()
         if not supported_entity_contract() or not supported_permission_contract():

--- a/trusts/models.py
+++ b/trusts/models.py
@@ -19,7 +19,7 @@ from trusts.context import (
     check_registration,
 )
 from trusts.trustee import Trustee, TrusteeMixin
-from trusts.query import is_active_principal, trust_grant_q
+from trusts.query import compose_zero_path, is_active_principal, trust_grant_q
 from trusts.conditions import (
     Expr,
     PermissionConditionError,
@@ -232,19 +232,28 @@ class ContentQuerySet(models.QuerySet):
         condition`` in SQL (paginate the returned QuerySet). Callables
         raise ``PermissionConditionNotQueryable`` so they cannot
         over-grant.
+
+        The relational grant is the composed ``AuthorizationPath``
+        predicate (same seam as object-level ``has_perm``). Anonymous
+        principals stay empty; other non-requester values fail closed.
         """
+        from trusts.query import require_configured_requester
+
         condition_q = None
         if permission_has_condition(perm):
             condition_q = compile_registered_condition_q(self.model, perm, user)
+        if user is None or getattr(user, 'is_anonymous', False):
+            return self.none()
+        require_configured_requester(user)
         if not is_active_principal(user):
             return self.none()
         if not supported_entity_contract() or not supported_permission_contract():
             return self.none()
         permission = resolve_content_permission(self.model, perm)
-        prepare_context_registry()
-        granted = trust_grant_q(
-            user, permission, trust_fk=Context.scope_path(self.model),
-        )
+        path = compose_zero_path(self.model, permission)
+        if path is None:
+            return self.none()
+        granted = path.grant_q(user, permission)
         if condition_q is None:
             return self.filter(granted).distinct()
         return self.filter(granted & condition_q).distinct()

--- a/trusts/query.py
+++ b/trusts/query.py
@@ -19,8 +19,10 @@ from trusts.path import AuthorizationPathError, compose
 def is_active_principal(user):
     """Match ``User.has_perm``: anonymous and inactive principals are denied.
 
-    Superuser short-circuit on ``has_perm`` is a Django ``ModelBackend``
-    behavior and is not duplicated in SQL list filters.
+    Django ``PermissionsMixin.has_perm`` still short-circuits active
+    superusers before backends run (including ``obj=None``). Object-level
+    ``TrustModelBackend.has_perm`` and ``.permitted()`` evaluate the
+    composed grant instead; they do not treat superuser as return-all.
     """
     if user is None:
         return False

--- a/trusts/query.py
+++ b/trusts/query.py
@@ -1,17 +1,19 @@
-"""SQL grant filters shared by list APIs and trust-row checks.
+"""Zero evaluation helpers on the composed AuthorizationPath seam.
 
-These expressions JOIN the same trustee / TrustGroup / ceiling tables
-that ``TrustModelBackend.get_all_permissions`` reads. They are compiled
-from the frozen Trustee adapter set. Callers must apply them on a
-QuerySet (then paginate). They are not Python predicates.
+``direct`` / ``group`` adapter gating, Django user flags, and
+``auth.Permission`` resolution stay here as concrete-policy concerns.
+Kernel ``compose`` does not know those nouns.
 
-Group-derived access is fail-closed. A group permission matches only when
-the user is a member, a ``TrustGroup`` row exists, the permission is in
-``TrustGroup.permissions``, and the permission is in the group's global
-ceiling (``Group.permissions`` or role-derived). Incomplete rows deny.
+Resource-origin list and object checks (``ContentQuerySet.permitted``,
+``TrustModelBackend`` object permissions) go through ``compose``.
+Create-under-trust still uses ``Trustee.grant_q`` with an empty
+``scope_from_row`` because ``Trust`` as Content is registered with the
+parent hop (``resource_to_scope='trust'``), not identity.
 """
 
-from django.db.models import Exists, Q
+from django.db.models import Q, QuerySet
+
+from trusts.path import AuthorizationPathError, compose
 
 
 def is_active_principal(user):
@@ -29,12 +31,6 @@ def is_active_principal(user):
     if not getattr(user, 'is_active', False):
         return False
     return True
-
-
-def _never_exists():
-    from trusts.models import TrustGroup
-
-    return Exists(TrustGroup.objects.none())
 
 
 def _group_permission_queries_allowed():
@@ -74,62 +70,158 @@ def enabled_trustee_adapter_names():
     )
 
 
-def _scope_from_row_for_outerref(trust_id_outerref):
-    if trust_id_outerref == 'pk':
-        return ''
-    if isinstance(trust_id_outerref, str) and trust_id_outerref.endswith('_id'):
-        return trust_id_outerref[:-3]
-    return trust_id_outerref
+def _model_label(model):
+    meta = getattr(model, '_meta', None)
+    if meta is not None:
+        return meta.label
+    return repr(model)
 
 
-def group_local_grant_exists(user, permission, trust_id_outerref):
-    """Exists: same TrustGroup, member, local grant, and global ceiling.
+def _same_model(left, right):
+    if not isinstance(left, type):
+        left = left.__class__
+    if not isinstance(right, type):
+        right = right.__class__
+    return left._meta.concrete_model is right._meta.concrete_model
 
-    ``trust_id_outerref`` is the outer row's Trust PK column (``pk`` on
-    Trust, ``trust_id`` on Content). Compiled from the Group Trustee
-    adapter.
-    """
-    from trusts.models import GROUP_TRUSTEE, prepare_trustee_registry
+
+def _require_terminal_instance(value, expected_model, what):
+    """Reject raw PKs and wrong models so Django cannot coerce a colliding PK."""
+    if isinstance(value, type):
+        raise AuthorizationPathError(
+            '%s must be a %s instance, not a model class.' % (
+                what, _model_label(expected_model),
+            )
+        )
+    meta = getattr(value, '_meta', None)
+    if meta is None:
+        raise AuthorizationPathError(
+            '%s must be a %s instance, not %r. Raw primary keys are '
+            'not accepted.' % (what, _model_label(expected_model), value)
+        )
+    if not _same_model(value, expected_model):
+        raise AuthorizationPathError(
+            '%s is %s, which is not the configured %s %s.' % (
+                what, _model_label(value.__class__),
+                what, _model_label(expected_model),
+            )
+        )
+    return value
+
+
+def require_configured_requester(user):
+    """Fail closed unless ``user`` is an instance of the configured requester."""
+    from trusts.models import prepare_trustee_registry
     from trusts.trustee import Trustee
 
-    if not _group_permission_queries_allowed():
-        return _never_exists()
-
     prepare_trustee_registry()
-    return Trustee.get(GROUP_TRUSTEE).exists_q(
-        user, permission, _scope_from_row_for_outerref(trust_id_outerref),
+    return _require_terminal_instance(
+        user, Trustee.registry.requester_model(), 'requester',
     )
 
 
-def permission_granted_via_group_exists(user, trusts):
-    """Exists against an outer Permission queryset for ``user`` on ``trusts``.
-
-    ``trusts`` is a Trust instance, queryset, or id list. Empty ``trust__in``
-    matches nothing. Compiled from the Group Trustee adapter.
-    """
-    from trusts.models import GROUP_TRUSTEE, prepare_trustee_registry
+def require_configured_operation(operation):
+    """Fail closed unless ``operation`` is an instance of the configured operation."""
+    from trusts.models import prepare_trustee_registry
     from trusts.trustee import Trustee
 
-    if not _group_permission_queries_allowed():
-        return _never_exists()
-
     prepare_trustee_registry()
-    return Trustee.get(GROUP_TRUSTEE).operation_exists_q(user, trusts)
+    return _require_terminal_instance(
+        operation, Trustee.registry.operation_model(), 'operation',
+    )
+
+
+def compose_zero_path(resource_model, operation):
+    """Compose process-wide maps with Zero-enabled adapter names.
+
+    Returns ``None`` when no adapters remain after auth-model gating.
+    Unregistered resources and mismatched terminals raise
+    ``AuthorizationPathError``.
+    """
+    from trusts.models import prepare_context_registry, prepare_trustee_registry
+
+    prepare_context_registry()
+    prepare_trustee_registry()
+    names = enabled_trustee_adapter_names()
+    if not names:
+        return None
+    return compose(resource_model, operation, names=names)
+
+
+def filter_zero_granted(queryset, requester, operation):
+    """SQL-filter ``queryset`` through the composed Zero path (one query)."""
+    path = compose_zero_path(queryset.model, operation)
+    if path is None:
+        return queryset.none()
+    return path.filter_granted(queryset, requester, operation)
+
+
+def row_is_zero_granted(obj, requester, operation):
+    """One-query exists check through the composed Zero path."""
+    path = compose_zero_path(obj.__class__, operation)
+    if path is None:
+        return False
+    return path.row_is_granted(obj, requester, operation)
+
+
+def queryset_is_zero_granted(queryset, requester, operation):
+    """True when ``queryset`` is non-empty and every row is granted.
+
+    Empty querysets deny (same as ``get_all_permissions`` on an empty
+    content queryset). The ungranted remainder uses the same ``grant_q``
+    as ``filter_zero_granted``.
+    """
+    if not isinstance(queryset, QuerySet):
+        raise AuthorizationPathError(
+            'queryset must be a QuerySet, not %r.' % (queryset,)
+        )
+    if not queryset.exists():
+        return False
+    path = compose_zero_path(queryset.model, operation)
+    if path is None:
+        return False
+    granted = path.grant_q(requester, operation)
+    return not queryset.exclude(granted).exists()
+
+
+def scope_pks_from_resource(obj, path):
+    """Primary keys of scopes reached by ``path.resource_to_scope``.
+
+    Resource-origin lookup (the composed Context hop), not a Trust-origin
+    reverse. Used by ``get_all_permissions`` enumeration only.
+    """
+    lookup = path.resource_to_scope
+    if isinstance(obj, QuerySet):
+        return tuple(
+            pk for pk in obj.values_list(lookup, flat=True).distinct()
+            if pk is not None
+        )
+    model = obj.__class__
+    pk = model._default_manager.filter(pk=obj.pk).values_list(
+        lookup, flat=True,
+    ).first()
+    if pk is None:
+        return ()
+    return (pk,)
 
 
 def trust_grant_q(user, permission, trust_fk=''):
-    """Return a Q matching trustee grants or the group local/global intersection.
+    """Q matching grants when the filtered row *is* the scope.
 
-    ``trust_fk`` is the lookup prefix to the Trust row:
-    - ``''`` filters ``Trust`` rows themselves (create-under-trust).
-    - ``'trust'`` filters Content rows via ``Content.trust``.
+    ``trust_fk`` is the lookup prefix to the scope row: ``''`` filters
+    ``Trust`` rows themselves (create-under-trust / ``has_trust_row_perm``).
+    Resource-origin Content filters must use ``compose_zero_path`` /
+    ``filter_zero_granted`` instead of passing ``Context.scope_path``.
 
-    Direct-object checks and permitted querysets share this compiled
-    predicate.
+    Requester and operation must be instances of the configured
+    terminals; raw PKs and same-PK collisions of the wrong model fail
+    closed.
     """
     from trusts.models import prepare_trustee_registry
     from trusts.trustee import Trustee
 
+    require_configured_requester(user)
+    require_configured_operation(permission)
     prepare_trustee_registry()
     names = enabled_trustee_adapter_names()
     if not names:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **Step 2 only** of [#43](https://github.com/django-trusts/django-trusts/issues/43) from accepted `noun-independent-kernel-r3`, on master after PR #44 (`8439dbc89cb0be0dfd055beeed454f3b708f256c`).

- Route `ContentQuerySet.permitted` and object-level `TrustModelBackend` evaluation through `AuthorizationPath.compose` rather than a parallel Context+Trustee / `filter_by_content` join.
- Keep `direct` / `group` adapter names, Django Permission strings, `TrustModelBackend`, callable conditions, and `Content.is_content` as Zero policy — not kernel assumptions.
- Preserve current User / Group-local/global intersection / Role-as-ceiling / condition / custom-user / inactive-user / backend-composition allow/deny.
- Same-PK and raw-PK requesters fail closed at public compatibility entry points.
- Deletion report in `migrates.md` for noun-dependent query branches that became redundant.
- Object-level active superusers go through the same composed grant as other requesters (Chat review `5151978297` / #43 comment `5599113469`). `obj=None` still uses Django's model-level path. `User.has_perm` without an object still short-circuits via `PermissionsMixin`. Unknown permission codes deny (`Permission` or `ContentType` missing), they do not raise.

Does **not** close #43. No Zero relocation, no schema/data change, no recursive/ordered implementation. Do not start Step 3.

HEAD: `06a259adcbf6fca5dffc07e496a91d2f5cb851db`

## Design

Zero wrappers (`compose_zero_path`, `row_is_zero_granted`, `filter_zero_granted`) pass `names=enabled_trustee_adapter_names()` into `compose`. Create-under-trust still uses empty `scope_from_row` because `Trust` as Content is registered with the parent hop.

Unregistered stuffed lookups still raise `InvalidContentFieldlookup`. Missing Permission strings deny. Junction table rows still do not enter `User.has_perm`.

## Tests

Local results on this SHA:

- `python -m tests.runtests`: 339 tests, OK (1 expected failure)
- `python -m tests.runtests_custom`: 7 tests, OK
- `python -m django check` (default and custom): clean
- `python scripts/verify-legacy-upgrade.py`: ok (`{0001_initial, 0002_trustgroup}`)

GitHub CI on this SHA ([run 34332197738](https://github.com/django-trusts/django-trusts/actions/runs/34332197738)): package + tests (Python 3.12 / 3.13 / 3.14) all **success**. The earlier red run ([34331711573](https://github.com/django-trusts/django-trusts/actions/runs/34331711573)) was superseded SHA `4b11a92` (`tests.nosuch_category` / `ContentType.DoesNotExist`).

`tests.core.test_zero_path` covers compose consumer, source deletion, Junction gate, same-PK / raw-PK fail-closed, `has_perm` ≡ `.permitted()`, fixed-query, and object-level superuser grant regressions (ungranted absent, granted present, Junction/unregistered/unknown-perm denied).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b55b2b84-a813-4a20-a4e9-e9d7a0e2e87e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b55b2b84-a813-4a20-a4e9-e9d7a0e2e87e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

